### PR TITLE
redirect to applicant base url when user not logged in

### DIFF
--- a/packages/admin/.snyk
+++ b/packages/admin/.snyk
@@ -2,38 +2,16 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-XML2JS-5414874:
-    - '*':
-        reason: >-
-          vulnerability in internal AWS communication so attacker would have to
-          compromise AWS, no upgrade to affected dependency currently available
-        expires: 2023-07-07T10:44:52.403Z
-        created: 2023-06-07T10:44:52.405Z
-  SNYK-JS-JSON5-3182856:
-    - '*':
-        reason: 'dependency used during local dev, no upgrade currently available'
-        expires: 2023-07-07T10:45:52.287Z
-        created: 2023-06-07T10:45:52.294Z
-  SNYK-JS-LOADERUTILS-3042992:
-    - '*':
-        reason: 'dependency used during build, no upgrade currently available'
-        expires: 2023-07-07T10:46:50.010Z
-        created: 2023-06-07T10:46:50.015Z
-  SNYK-JS-LOADERUTILS-3105943:
-    - '*':
-        reason: 'dependency used during build, no upgrade currently available'
-        expires: 2023-07-07T10:47:19.004Z
-        created: 2023-06-07T10:47:19.009Z
   SNYK-JS-WORDWRAP-3149973:
     - '*':
         reason: 'dependency used during local dev, no upgrade currently available'
-        expires: 2023-07-07T10:51:19.334Z
+        expires: 2023-08-31T10:51:19.334Z
         created: 2023-06-07T10:51:19.355Z
   SNYK-JS-SEMVER-3247795:
     - '*':
         reason: >-
           dependency only used during dev and build, no upgrade currently
           available
-        expires: 2023-07-21T14:47:46.319Z
+        expires: 2023-08-31T14:47:46.319Z
         created: 2023-06-21T14:47:46.321Z
 patch: {}

--- a/packages/applicant/.snyk
+++ b/packages/applicant/.snyk
@@ -2,38 +2,16 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-XML2JS-5414874:
-    - '*':
-        reason: >-
-          vulnerability in internal AWS communication so attacker would have to
-          compromise AWS, no upgrade to affected dependency currently available
-        expires: 2023-07-07T10:44:52.403Z
-        created: 2023-06-07T10:44:52.405Z
-  SNYK-JS-JSON5-3182856:
-    - '*':
-        reason: 'dependency used during local dev, no upgrade currently available'
-        expires: 2023-07-07T10:45:52.287Z
-        created: 2023-06-07T10:45:52.294Z
-  SNYK-JS-LOADERUTILS-3042992:
-    - '*':
-        reason: 'dependency used during build, no upgrade currently available'
-        expires: 2023-07-07T10:46:50.010Z
-        created: 2023-06-07T10:46:50.015Z
-  SNYK-JS-LOADERUTILS-3105943:
-    - '*':
-        reason: 'dependency used during build, no upgrade currently available'
-        expires: 2023-07-07T10:47:19.004Z
-        created: 2023-06-07T10:47:19.009Z
   SNYK-JS-WORDWRAP-3149973:
     - '*':
         reason: 'dependency used during local dev, no upgrade currently available'
-        expires: 2023-07-07T10:51:19.334Z
+        expires: 2023-08-31T10:51:19.334Z
         created: 2023-06-07T10:51:19.355Z
   SNYK-JS-SEMVER-3247795:
     - '*':
         reason: >-
           dependency only used during dev and build, no upgrade currently
           available
-        expires: 2023-07-21T14:47:46.319Z
+        expires: 2023-08-31T14:47:46.319Z
         created: 2023-06-21T14:47:46.321Z
 patch: {}

--- a/packages/applicant/jest.config.js
+++ b/packages/applicant/jest.config.js
@@ -8,8 +8,6 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  // Add more setup options before each test is run
-  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   rootDir: './',
   moduleDirectories: ['node_modules', '<rootDir>/'],

--- a/packages/applicant/package.json
+++ b/packages/applicant/package.json
@@ -70,11 +70,13 @@
     "eslint": "8.42.0",
     "eslint-config-next": "12.0.7",
     "eslint-config-prettier": "^8.5.0",
+    "isomorphic-fetch": "3.0.0",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
     "prettier": "^2.6.2",
     "sass": "1.62.1",
-    "typescript": "^4.6.3"
+    "typescript": "^4.6.3",
+    "urlpattern-polyfill": "9.0.0"
   },
   "browserslist": {
     "production": [

--- a/packages/applicant/setupJestMock.js
+++ b/packages/applicant/setupJestMock.js
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+import 'isomorphic-fetch';
+import 'urlpattern-polyfill';
 
 jest.mock('csurf', () => {
   return {

--- a/packages/applicant/src/middleware.page.ts
+++ b/packages/applicant/src/middleware.page.ts
@@ -25,9 +25,8 @@ function isWithinNumberOfMinsOfExpiry(expiresAt: Date, numberOfMins: number) {
   return expiresAt >= now && expiresAt <= nowPlusMins;
 }
 
-function buildMiddlewareResponse(req: NextRequest, redirectUri: string) {
+export function buildMiddlewareResponse(req: NextRequest, redirectUri: string) {
   const res = NextResponse.redirect(redirectUri);
-
   if (newApplicationPattern.test({ pathname: req.nextUrl.pathname })) {
     res.cookies.set(
       process.env.APPLYING_FOR_REDIRECT_COOKIE,
@@ -64,7 +63,7 @@ export async function middleware(req: NextRequest) {
       console.error(err);
     }
 
-    const res = buildMiddlewareResponse(req, process.env.LOGIN_URL);
+    const res = buildMiddlewareResponse(req, HOST);
     return res;
   }
 
@@ -73,7 +72,7 @@ export async function middleware(req: NextRequest) {
     const expiresAt = new Date(validJwtResponse.expiresAt);
 
     if (!validJwtResponse.valid) {
-      return buildMiddlewareResponse(req, process.env.LOGIN_URL);
+      return buildMiddlewareResponse(req, HOST);
     }
 
     if (isWithinNumberOfMinsOfExpiry(expiresAt, 30)) {
@@ -85,7 +84,7 @@ export async function middleware(req: NextRequest) {
   } catch (err) {
     console.error('middleware error');
     console.error(err);
-    return NextResponse.redirect(process.env.LOGIN_URL);
+    return NextResponse.redirect(HOST);
   }
 }
 

--- a/packages/applicant/src/middleware.test.ts
+++ b/packages/applicant/src/middleware.test.ts
@@ -1,0 +1,83 @@
+import { middleware, buildMiddlewareResponse } from './middleware.page';
+// eslint-disable-next-line @next/next/no-server-import-in-page
+import { NextRequest } from 'next/server';
+import { verifyToken } from './services/JwtService';
+
+jest.mock('./services/JwtService');
+
+global.fetch = jest.fn();
+const mockedFetch = jest.mocked(global.fetch);
+const mockedVerifyToken = jest.mocked(verifyToken);
+
+describe('Middleware', () => {
+  beforeEach(jest.clearAllMocks);
+
+  it('redirects to host if response is not OK or JWT is undefined', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: false,
+      text: jest.fn().mockResolvedValueOnce('undefined'),
+    } as unknown as Response);
+
+    const req = new NextRequest(new Request('https://some.website.com/page'));
+    const res = await middleware(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe(process.env.HOST);
+  });
+
+  it('redirects to host if JWT is not valid', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      text: jest.fn().mockResolvedValueOnce('someJwt'),
+    } as unknown as Response);
+
+    mockedVerifyToken.mockResolvedValueOnce({ valid: false });
+
+    const req = new NextRequest(new Request('https://some.website.com/page'));
+    const res = await middleware(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe(process.env.HOST);
+  });
+
+  it('redirects to refresh URL if JWT is close to expiration', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      text: jest.fn().mockResolvedValueOnce('someJwt'),
+    } as unknown as Response);
+
+    const expiresAt = new Date();
+    expiresAt.setMinutes(expiresAt.getMinutes() + 10); // Expiring in 10 minutes
+
+    mockedVerifyToken.mockResolvedValueOnce({
+      valid: true,
+      expiresAt: expiresAt.toISOString(),
+    });
+
+    const req = new NextRequest(new Request('https://some.website.com/test'));
+    const res = await middleware(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe(
+      `${process.env.REFRESH_URL}?redirectUrl=${process.env.HOST}/test`
+    );
+  });
+
+  it('sets redirect cookie if URL matches new application pattern', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      text: jest.fn().mockResolvedValueOnce('someJwt'),
+    } as unknown as Response);
+    const pathname = 'applications/123';
+    const applicationId = '123';
+
+    const req = new NextRequest(
+      new Request(`https://some.website.com/${pathname}`)
+    );
+    const res = buildMiddlewareResponse(req, process.env.HOST);
+
+    expect(res.cookies.get(process.env.APPLYING_FOR_REDIRECT_COOKIE)).toEqual(
+      applicationId
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,6 +5782,7 @@ __metadata:
     govuk-frontend: 4.2.0
     gray-matter: 4.0.3
     imap-simple: ^5.1.0
+    isomorphic-fetch: 3.0.0
     jest: ^28.1.2
     jest-environment-jsdom: ^28.1.2
     jsonwebtoken: ^9.0.0
@@ -5804,6 +5805,7 @@ __metadata:
     sass: 1.62.1
     swr: ^0.5.5
     typescript: ^4.6.3
+    urlpattern-polyfill: 9.0.0
   languageName: unknown
   linkType: soft
 
@@ -11279,6 +11281,16 @@ __metadata:
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
   checksum: db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
+  languageName: node
+  linkType: hard
+
+"isomorphic-fetch@npm:3.0.0":
+  version: 3.0.0
+  resolution: "isomorphic-fetch@npm:3.0.0"
+  dependencies:
+    node-fetch: ^2.6.1
+    whatwg-fetch: ^3.4.1
+  checksum: e5ab79a56ce5af6ddd21265f59312ad9a4bc5a72cebc98b54797b42cb30441d5c5f8d17c5cd84a99e18101c8af6f90c081ecb8d12fd79e332be1778d58486d75
   languageName: node
   linkType: hard
 
@@ -17678,6 +17690,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"urlpattern-polyfill@npm:9.0.0":
+  version: 9.0.0
+  resolution: "urlpattern-polyfill@npm:9.0.0"
+  checksum: d3658b78a10eaee514c464f5a4336c408c70cf01e9b915cb1df5892b3c49003d1ed4042dc72d1b18493b8b847883e84fbf2bf358abb5dff84b2725d5e8463bcb
+  languageName: node
+  linkType: hard
+
 "use-resize-observer@npm:^9.1.0":
   version: 9.1.0
   resolution: "use-resize-observer@npm:9.1.0"
@@ -17987,6 +18006,13 @@ __metadata:
   dependencies:
     iconv-lite: 0.6.3
   checksum: 7087810c410aa9b689cbd6af8773341a53cdc1f3aae2a882c163bd5522ec8ca4cdfc269aef417a5792f411807d5d77d50df4c24e3abb00bb60192858a40cc675
+  languageName: node
+  linkType: hard
+
+"whatwg-fetch@npm:^3.4.1":
+  version: 3.6.17
+  resolution: "whatwg-fetch@npm:3.6.17"
+  checksum: 0a8785dc2d1515c17ee9365d3f6438cf8fd281567426652fc6c55fc99e58cc6287ae5d1add5b8b1dd665f149e38d3de4ebe3812fd7170438ba0681d03b88b4dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Amends applicant middleware to direct user to root applicant page (ie the page that asks you to register or login) when user not logged in or error reading JWT.

Adds test suite for applicant `middleware.page.ts`.

Installs polyfills required for above test to work in Node 16.