### PR TITLE
Migration error/success banners

### DIFF
--- a/packages/admin/src/pages/dashboard/index.page.tsx
+++ b/packages/admin/src/pages/dashboard/index.page.tsx
@@ -21,20 +21,24 @@ export const getServerSideProps = async ({
     size: 2,
     sort: 'createdDate,DESC',
   };
-  const migrationSucceeded =
-    (query?.migrationSucceeded as string | undefined) ?? null;
   const sessionCookie = getSessionIdFromCookies(req);
   const schemes = await getUserSchemes(paginationParams, sessionCookie);
   const userDetails: UserDetails = await getLoggedInUsersDetails(sessionCookie);
+
+  const migrationStatus = query?.migrationStatus ?? null;
   const oneLoginTransferErrorEnabled =
     process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED === 'true';
+  const showMigrationSuccessBanner =
+    oneLoginTransferErrorEnabled && migrationStatus === 'success';
+  const showMigrationErrorBanner =
+    oneLoginTransferErrorEnabled && migrationStatus === 'error';
 
   return {
     props: {
       schemes: schemes,
       userDetails,
-      oneLoginTransferErrorEnabled,
-      migrationSucceeded,
+      showMigrationSuccessBanner,
+      showMigrationErrorBanner,
     },
   };
 };
@@ -42,21 +46,21 @@ export const getServerSideProps = async ({
 const Dashboard = ({
   schemes,
   userDetails,
-  oneLoginTransferErrorEnabled,
-  migrationSucceeded,
+  showMigrationSuccessBanner,
+  showMigrationErrorBanner,
 }: InferProps<typeof getServerSideProps>) => {
   return (
     <div className="govuk-grid-row govuk-!-padding-top-7">
       <Meta title="Dashboard - Manage a grant" />
       <div className="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-        {oneLoginTransferErrorEnabled && migrationSucceeded === 'true' && (
+        {showMigrationSuccessBanner && (
           <ImportantBanner
             bannerHeading="Your data has been successfully added to your One Login account."
-            successBanner
+            isSuccess
           />
         )}
 
-        {oneLoginTransferErrorEnabled && migrationSucceeded === 'false' && (
+        {showMigrationErrorBanner && (
           <ImportantBanner
             bannerHeading="Something went wrong while transferring your data. "
             bannerContent={

--- a/packages/admin/src/pages/dashboard/index.page.tsx
+++ b/packages/admin/src/pages/dashboard/index.page.tsx
@@ -60,7 +60,7 @@ const Dashboard = ({
             bannerHeading="Your data has been successfully added to your One Login account."
             bannerContent={
               <p className="govuk-body">
-                Please get in contact with our support team at
+                Please get in contact with our support team at{' '}
                 <a
                   className="govuk-notification-banner__link"
                   href="mailto:findagrant@cabinetoffice.gov.uk"

--- a/packages/admin/src/pages/dashboard/index.page.tsx
+++ b/packages/admin/src/pages/dashboard/index.page.tsx
@@ -57,7 +57,7 @@ const Dashboard = ({
 
         {oneLoginTransferErrorEnabled && migrationSucceeded === 'false' && (
           <ImportantBanner
-            bannerHeading="Your data has been successfully added to your One Login account."
+            bannerHeading="Something went wrong while transferring your data. "
             bannerContent={
               <p className="govuk-body">
                 Please get in contact with our support team at{' '}

--- a/packages/admin/src/pages/dashboard/index.page.tsx
+++ b/packages/admin/src/pages/dashboard/index.page.tsx
@@ -1,7 +1,6 @@
 import Meta from '../../components/layout/Meta';
 import AccountDetails from './AccountDetails';
 import ManageGrantSchemes from './ManageGrantSchemes';
-import Scheme from '../../types/Scheme';
 import { getUserSchemes } from '../../services/SchemeService';
 import Pagination from '../../types/Pagination';
 import { getLoggedInUsersDetails } from '../../services/UserService';
@@ -10,9 +9,11 @@ import { getSessionIdFromCookies } from '../../utils/session';
 import { GetServerSidePropsContext } from 'next';
 import CustomLink from '../../components/custom-link/CustomLink';
 import InferProps from '../../types/InferProps';
+import { ImportantBanner } from 'gap-web-ui';
 
 export const getServerSideProps = async ({
   req,
+  query,
 }: GetServerSidePropsContext) => {
   const paginationParams: Pagination = {
     paginate: true,
@@ -20,7 +21,7 @@ export const getServerSideProps = async ({
     size: 2,
     sort: 'createdDate,DESC',
   };
-
+  const migrationSucceeded = query?.migrationSucceeded as string | undefined;
   const sessionCookie = getSessionIdFromCookies(req);
   const schemes = await getUserSchemes(paginationParams, sessionCookie);
   const userDetails: UserDetails = await getLoggedInUsersDetails(sessionCookie);
@@ -31,7 +32,8 @@ export const getServerSideProps = async ({
     props: {
       schemes: schemes,
       userDetails,
-      oneLoginTransferErrorEnabled: Boolean(oneLoginTransferErrorEnabled),
+      oneLoginTransferErrorEnabled,
+      migrationSucceeded,
     },
   };
 };
@@ -40,17 +42,37 @@ const Dashboard = ({
   schemes,
   userDetails,
   oneLoginTransferErrorEnabled,
+  migrationSucceeded,
 }: InferProps<typeof getServerSideProps>) => {
   return (
     <div className="govuk-grid-row govuk-!-padding-top-7">
       <Meta title="Dashboard - Manage a grant" />
       <div className="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-        {oneLoginTransferErrorEnabled && (
-          /* TODO: Placeholder for GAP-2013 */
-          <div>
-            <h1>PLACEHOLDER FOR ERROR BANNER</h1>
-          </div>
+        {oneLoginTransferErrorEnabled && migrationSucceeded === 'true' && (
+          <ImportantBanner
+            bannerHeading="Your data has been successfully added to your One Login account."
+            successBanner
+          />
         )}
+
+        {oneLoginTransferErrorEnabled && migrationSucceeded === 'false' && (
+          <ImportantBanner
+            bannerHeading="Your data has been successfully added to your One Login account."
+            bannerContent={
+              <p className="govuk-body">
+                Please get in contact with our support team at
+                <a
+                  className="govuk-notification-banner__link"
+                  href="mailto:findagrant@cabinetoffice.gov.uk"
+                >
+                  findagrant@cabinetoffice.gov.uk
+                </a>
+                {'.'}
+              </p>
+            }
+          />
+        )}
+
         <AccountDetails userDetails={userDetails} />
         <ManageGrantSchemes schemes={schemes} />
 

--- a/packages/admin/src/pages/dashboard/index.page.tsx
+++ b/packages/admin/src/pages/dashboard/index.page.tsx
@@ -21,7 +21,8 @@ export const getServerSideProps = async ({
     size: 2,
     sort: 'createdDate,DESC',
   };
-  const migrationSucceeded = query?.migrationSucceeded as string | undefined;
+  const migrationSucceeded =
+    (query?.migrationSucceeded as string | undefined) ?? null;
   const sessionCookie = getSessionIdFromCookies(req);
   const schemes = await getUserSchemes(paginationParams, sessionCookie);
   const userDetails: UserDetails = await getLoggedInUsersDetails(sessionCookie);

--- a/packages/admin/src/pages/dashboard/index.test.tsx
+++ b/packages/admin/src/pages/dashboard/index.test.tsx
@@ -60,23 +60,8 @@ describe('Dashboard', () => {
         props: {
           schemes: mockSchemeList,
           userDetails: mockUserDetails,
-          oneLoginTransferErrorEnabled: false,
-          migrationSucceeded: null,
-        },
-      });
-    });
-
-    it('Should return oneLoginTransferErrorEnabled = true', async () => {
-      process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED = 'true';
-
-      const result = await getServerSideProps(getContext(getDefaultContext));
-
-      expectObjectEquals(result, {
-        props: {
-          schemes: mockSchemeList,
-          userDetails: mockUserDetails,
-          oneLoginTransferErrorEnabled: true,
-          migrationSucceeded: null,
+          showMigrationSuccessBanner: false,
+          showMigrationErrorBanner: false,
         },
       });
     });
@@ -86,9 +71,9 @@ describe('Dashboard', () => {
     function getDefaultProps(): InferProps<typeof getServerSideProps> {
       return {
         schemes: mockSchemeList,
-        oneLoginTransferErrorEnabled: false,
+        showMigrationSuccessBanner: false,
+        showMigrationErrorBanner: false,
         userDetails: mockUserDetails,
-        migrationSucceeded: 'false',
       };
     }
 
@@ -102,7 +87,7 @@ describe('Dashboard', () => {
       render(
         <Dashboard
           {...getProps(getDefaultProps, {
-            oneLoginTransferErrorEnabled: true,
+            showMigrationErrorBanner: true,
           })}
         />
       );
@@ -128,8 +113,7 @@ describe('Dashboard', () => {
       render(
         <Dashboard
           {...getProps(getDefaultProps, {
-            oneLoginTransferErrorEnabled: true,
-            migrationSucceeded: 'true',
+            showMigrationSuccessBanner: true,
           })}
         />
       );

--- a/packages/admin/src/pages/dashboard/index.test.tsx
+++ b/packages/admin/src/pages/dashboard/index.test.tsx
@@ -140,7 +140,7 @@ describe('Dashboard', () => {
       );
     });
 
-    it('Should not render the success banner', () => {
+    it('does not render success banner when migrationSucceeded not passed', () => {
       render(<Dashboard {...getProps(getDefaultProps)} />);
 
       expect(

--- a/packages/admin/src/pages/dashboard/index.test.tsx
+++ b/packages/admin/src/pages/dashboard/index.test.tsx
@@ -5,18 +5,10 @@ import Dashboard, { getServerSideProps } from './index.page';
 import { getUserSchemes } from '../../services/SchemeService';
 import { getLoggedInUsersDetails } from '../../services/UserService';
 import UserDetails from '../../types/UserDetails';
+import InferProps from '../../types/InferProps';
+import { Optional, expectObjectEquals, getContext, getProps } from 'gap-web-ui';
+import { GetServerSidePropsContext } from 'next';
 
-jest.mock('next/config', () => () => {
-  return {
-    serverRuntimeConfig: {
-      backendHost: 'http://localhost:8080',
-    },
-    publicRuntimeConfig: {
-      SUB_PATH: '',
-      APPLICANT_DOMAIN: 'http://localhost:8080',
-    },
-  };
-});
 jest.mock('../../services/SchemeService');
 jest.mock('../../services/UserService');
 
@@ -45,222 +37,183 @@ const mockUserDetails: UserDetails = {
   organisationName: 'Testing Org',
 };
 
-const mockOneLoginTransferErrorEnabled = false;
-
 describe('Dashboard', () => {
   describe('getServerSideProps', () => {
-    const mockedGetUserSchemes = getUserSchemes as jest.MockedFn<
-      typeof getUserSchemes
-    >;
+    const mockedGetUserSchemes = jest.mocked(getUserSchemes);
+    const mockedGetLoggedInUsersDetails = jest.mocked(getLoggedInUsersDetails);
 
-    const mockedGetLoggedInUsersDetails =
-      getLoggedInUsersDetails as jest.MockedFn<typeof getLoggedInUsersDetails>;
+    function getDefaultContext(): Optional<GetServerSidePropsContext> {
+      return {};
+    }
 
-    it('Should return a list of schemes', async () => {
+    beforeEach(() => {
       mockedGetUserSchemes.mockResolvedValue(mockSchemeList);
       mockedGetLoggedInUsersDetails.mockResolvedValue(mockUserDetails);
-
       process.env.SESSION_COOKIE_NAME = 'gap-test';
+    });
 
-      const result = await getServerSideProps({
-        req: { cookies: { 'gap-test': 'testSessionId' } },
-      } as any);
+    it('Should return a list of schemes', async () => {
+      const result = await getServerSideProps(getContext(getDefaultContext));
 
-      expect(result).toStrictEqual({
+      expectObjectEquals(result, {
         props: {
           schemes: mockSchemeList,
           userDetails: mockUserDetails,
           oneLoginTransferErrorEnabled: false,
+          migrationSucceeded: undefined,
         },
       });
     });
 
     it('Should return oneLoginTransferErrorEnabled = true', async () => {
-      mockedGetUserSchemes.mockResolvedValue(mockSchemeList);
-      mockedGetLoggedInUsersDetails.mockResolvedValue(mockUserDetails);
-
-      process.env.SESSION_COOKIE_NAME = 'gap-test';
       process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED = 'true';
 
-      const result = await getServerSideProps({
-        req: { cookies: { 'gap-test': 'testSessionId' } },
-      } as any);
+      const result = await getServerSideProps(getContext(getDefaultContext));
 
-      expect(result).toStrictEqual({
+      expectObjectEquals(result, {
         props: {
           schemes: mockSchemeList,
           userDetails: mockUserDetails,
           oneLoginTransferErrorEnabled: true,
-        },
-      });
-    });
-
-    it('Should return oneLoginTransferErrorEnabled = false', async () => {
-      mockedGetUserSchemes.mockResolvedValue(mockSchemeList);
-      mockedGetLoggedInUsersDetails.mockResolvedValue(mockUserDetails);
-
-      process.env.SESSION_COOKIE_NAME = 'gap-test';
-
-      const oneLoginTransferErrorEnabled =
-        process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED === 'true';
-
-      const result = await getServerSideProps({
-        req: { cookies: { 'gap-test': 'testSessionId' } },
-      } as any);
-
-      expect(result).toStrictEqual({
-        props: {
-          schemes: mockSchemeList,
-          userDetails: mockUserDetails,
-          oneLoginTransferErrorEnabled: oneLoginTransferErrorEnabled,
+          migrationSucceeded: undefined,
         },
       });
     });
   });
 
   describe('Dashboard page render', () => {
-    it('Should render the error banner', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={true}
-        />
-      );
-      screen.getByRole('heading', { name: 'PLACEHOLDER FOR ERROR BANNER' });
-    });
-
-    it('Should not render the error banner', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={false}
-        />
-      );
-      expect(screen.queryByText('PLACEHOLDER FOR ERROR BANNER')).toBeFalsy();
-    });
+    function getDefaultProps(): InferProps<typeof getServerSideProps> {
+      return {
+        schemes: mockSchemeList,
+        oneLoginTransferErrorEnabled: false,
+        userDetails: mockUserDetails,
+        migrationSucceeded: 'false',
+      };
+    }
 
     it('Should render a page title', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       screen.getByRole('heading', { name: 'Manage a grant' });
     });
 
-    it('Should render the user email', () => {
+    it('Should render the error banner', () => {
       render(
         <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
+          {...getProps(getDefaultProps, {
+            oneLoginTransferErrorEnabled: true,
+          })}
         />
       );
+
+      screen.getByRole('heading', { level: 2, name: 'Important' });
+      screen.getByText('Something went wrong while transferring your data.');
+      expect(
+        screen.getByRole('link', {
+          name: 'findagrant@cabinetoffice.gov.uk',
+        })
+      ).toHaveAttribute('href', 'mailto:findagrant@cabinetoffice.gov.uk');
+    });
+
+    it('Should not render the error banner', () => {
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
+      expect(
+        screen.queryByRole('heading', { level: 2, name: 'Important' })
+      ).toBeFalsy();
+    });
+
+    it('Should render the success banner', () => {
+      render(
+        <Dashboard
+          {...getProps(getDefaultProps, {
+            oneLoginTransferErrorEnabled: true,
+            migrationSucceeded: 'true',
+          })}
+        />
+      );
+
+      screen.getByRole('heading', { level: 2, name: 'Success' });
+      screen.getByText(
+        'Your data has been successfully added to your One Login account.'
+      );
+    });
+
+    it('Should not render the success banner', () => {
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
+      expect(
+        screen.queryByRole('heading', { level: 2, name: 'Success' })
+      ).toBeFalsy();
+    });
+
+    it('Should render the user email', () => {
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       screen.getByText('test@email.com');
     });
 
     it('Should render the organisation name', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       screen.getByText('Testing Org');
     });
 
     it('Should render the "manage your grant scheme table" headings when there are schemes', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       screen.getByRole('columnheader', { name: 'Name' });
       screen.getByRole('columnheader', { name: 'Date created' });
     });
 
     it('Should render the "manage your grant scheme table" scheme names when there are schemes', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       screen.getByRole('cell', { name: 'Scheme name 1' });
       screen.getByRole('cell', { name: 'Scheme name 2' });
     });
 
     it('Should render the "manage your grant scheme table" scheme created at dates when there are schemes', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       screen.getByRole('cell', { name: '10 December 2011' });
       screen.getByRole('cell', { name: '10 October 2011' });
     });
 
     it('Should render the "manage your grant scheme table" scheme view links when there are schemes', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       expect(
         screen.getByRole('link', { name: 'View scheme Scheme name 1' })
-      ).toHaveAttribute('href', '/scheme/123');
+      ).toHaveAttribute('href', '/apply/scheme/123');
       expect(
         screen.getByRole('link', { name: 'View scheme Scheme name 2' })
-      ).toHaveAttribute('href', '/scheme/456');
+      ).toHaveAttribute('href', '/apply/scheme/456');
     });
 
     it('Should render a View all schemes link to the schemes page when there are schemes', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       const viewAllSchemesElement = screen.getByRole('link', {
         name: 'View all grants',
       });
-      expect(viewAllSchemesElement).toHaveAttribute('href', '/scheme-list');
+      expect(viewAllSchemesElement).toHaveAttribute(
+        'href',
+        '/apply/scheme-list'
+      );
     });
 
     it('Should NOT render the "create new grant scheme" section when there are schemes', () => {
-      render(
-        <Dashboard
-          schemes={mockSchemeList}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps)} />);
+
       expect(
         screen.queryByTestId('create-new-grant-scheme-section')
       ).toBeFalsy();
     });
 
     it('Should NOT render the "manage your grant scheme table" when there are no schemes', () => {
-      render(
-        <Dashboard
-          schemes={[]}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps, { schemes: [] })} />);
+
       const manageGrantSchemeTable = screen.queryByTestId(
         'manage-grant-scheme-table'
       );
@@ -268,26 +221,16 @@ describe('Dashboard', () => {
     });
 
     it('Should render the "create new grant scheme" section when there are no schemes', () => {
-      render(
-        <Dashboard
-          schemes={[]}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps, { schemes: [] })} />);
+
       screen.getByRole('heading', { name: 'Add grant details' });
       screen.getByText('Start by adding the details of your grant.');
       screen.getByRole('button', { name: 'Add a grant' });
     });
 
     it('Should NOT render the "create new grant scheme" side bar when there are no schemes', () => {
-      render(
-        <Dashboard
-          schemes={[]}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps, { schemes: [] })} />);
+
       expect(
         screen.queryByText('Create new grant schemes to advertise your grants.')
       ).toBeFalsy();
@@ -297,13 +240,8 @@ describe('Dashboard', () => {
     });
 
     it('Should NOT render a View all schemes link to the schemes page when there are no schemes', () => {
-      render(
-        <Dashboard
-          schemes={[]}
-          userDetails={mockUserDetails}
-          oneLoginTransferErrorEnabled={mockOneLoginTransferErrorEnabled}
-        />
-      );
+      render(<Dashboard {...getProps(getDefaultProps, { schemes: [] })} />);
+
       expect(
         screen.queryByRole('link', { name: 'View all schemes' })
       ).toBeFalsy();

--- a/packages/admin/src/pages/dashboard/index.test.tsx
+++ b/packages/admin/src/pages/dashboard/index.test.tsx
@@ -124,7 +124,7 @@ describe('Dashboard', () => {
       ).toBeFalsy();
     });
 
-    it('Should render the success banner', () => {
+    it(`renders success banner when migrationSucceeded is 'true'`, () => {
       render(
         <Dashboard
           {...getProps(getDefaultProps, {

--- a/packages/admin/src/pages/dashboard/index.test.tsx
+++ b/packages/admin/src/pages/dashboard/index.test.tsx
@@ -50,6 +50,7 @@ describe('Dashboard', () => {
       mockedGetUserSchemes.mockResolvedValue(mockSchemeList);
       mockedGetLoggedInUsersDetails.mockResolvedValue(mockUserDetails);
       process.env.SESSION_COOKIE_NAME = 'gap-test';
+      process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED = 'false';
     });
 
     it('Should return a list of schemes', async () => {
@@ -60,7 +61,7 @@ describe('Dashboard', () => {
           schemes: mockSchemeList,
           userDetails: mockUserDetails,
           oneLoginTransferErrorEnabled: false,
-          migrationSucceeded: undefined,
+          migrationSucceeded: null,
         },
       });
     });
@@ -75,7 +76,7 @@ describe('Dashboard', () => {
           schemes: mockSchemeList,
           userDetails: mockUserDetails,
           oneLoginTransferErrorEnabled: true,
-          migrationSucceeded: undefined,
+          migrationSucceeded: null,
         },
       });
     });

--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/section-overview.page.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/section-overview.page.tsx
@@ -194,7 +194,7 @@ const SectionOverview = ({
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-two-thirds">
               <ImportantBanner
-                bannerContent="You need to review and publish your advert again, even if
+                bannerHeading="You need to review and publish your advert again, even if
                     you do not make any changes."
               />
             </div>

--- a/packages/admin/src/services/SchemeService.ts
+++ b/packages/admin/src/services/SchemeService.ts
@@ -11,7 +11,7 @@ const BACKEND_HOST = serverRuntimeConfig.backendHost;
 const BASE_SCHEME_URL = BACKEND_HOST + '/schemes';
 
 const getUserSchemes = async (pagination: Pagination, sessionId: string) => {
-  const response = await axios.get(`${BASE_SCHEME_URL}`, {
+  const response = await axios.get<Scheme[]>(`${BASE_SCHEME_URL}`, {
     params: pagination,
     ...axiosSessionConfig(sessionId),
   });

--- a/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
@@ -23,68 +23,27 @@ function getDefaultProps(): ApplicantDashBoardProps {
 }
 
 describe('Dashboard', () => {
-  test('should render 2 <hr/>', () => {
+  test('should render first section', () => {
     render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
 
-    const line = screen.getAllByRole('separator');
-    expect(line.length).toBe(2);
-  });
-
-  describe('should render first section', () => {
-    test('should render heading', () => {
-      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
-
-      const heading = screen.getByRole('heading', {
-        name: /your account/i,
-      });
-      expect(heading).toBeInTheDocument();
+    screen.getByRole('heading', {
+      name: /your account/i,
     });
-
-    test('should render table element', () => {
-      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
-
-      const nameKey = screen.getByRole('term', {
-        name: /name/i,
-      });
-      const nameValue = screen.getByText(/Sarah philips/i);
-
-      const organisationKey = screen.getByRole('term', {
-        name: /organisation/i,
-      });
-
-      const organisationValue = screen.getByText(/ABC Charity/i);
-
-      expect(nameKey).toBeInTheDocument();
-      expect(nameValue).toBeInTheDocument();
-      expect(organisationKey).toBeInTheDocument();
-      expect(organisationValue).toBeInTheDocument();
+    screen.getByRole('term', {
+      name: /name/i,
     });
-  });
-
-  describe('should render second section', () => {
-    test('should render heading', () => {
-      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
-
-      const heading = screen.getByRole('heading', {
-        name: /view your applications/i,
-      });
-      expect(heading).toBeInTheDocument();
+    screen.getByText(/Sarah philips/i);
+    screen.getByRole('term', {
+      name: /organisation/i,
     });
-
-    test('should render table element', () => {
-      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
-
-      const text = screen.getByText(/see your past and current applications/i);
-      expect(text).toBeInTheDocument();
+    screen.getByText(/ABC Charity/i);
+    screen.getByRole('heading', {
+      name: /view your applications/i,
     });
-
-    test('should render the link element and have the right href', () => {
-      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
-
-      expect(
-        screen.getByRole('link', { name: /view your applications/i })
-      ).toHaveAttribute('href', '/applications');
-    });
+    screen.getByText(/see your past and current applications/i);
+    expect(
+      screen.getByRole('link', { name: /view your applications/i })
+    ).toHaveAttribute('href', '/applications');
   });
 
   describe('should render second section when applicant has no applications', () => {
@@ -95,50 +54,17 @@ describe('Dashboard', () => {
         />
       );
 
+      screen.getByRole('heading', {
+        name: /your details/i,
+      });
       screen.getByText(/You have not started any applications\./i);
       screen.getByText(
         /To get started, you need to find a grant that you want to apply for\./i
       );
-    });
-
-    test('should find a grant button with correct href', () => {
-      render(
-        <ApplicantDashboard
-          {...getProps(getDefaultProps, { hasApplications: false })}
-        />
-      );
-
       expect(
         screen.getByRole('button', { name: /find a grant/i })
       ).toHaveAttribute('href', routes.findAGrant);
-    });
-  });
-
-  describe('should render third section', () => {
-    test('should render heading', () => {
-      render(
-        <ApplicantDashboard
-          {...getProps(getDefaultProps, { hasApplications: false })}
-        />
-      );
-
-      const heading = screen.getByRole('heading', {
-        name: /your details/i,
-      });
-      expect(heading).toBeInTheDocument();
-    });
-
-    test('should render the 2 cards', () => {
-      render(
-        <ApplicantDashboard
-          {...getProps(getDefaultProps, { hasApplications: false })}
-        />
-      );
-
-      const organisationCard = screen.getByText(
-        /Change your organisation details/i
-      );
-      expect(organisationCard).toBeInTheDocument();
+      screen.getByText(/Change your organisation details/i);
     });
   });
 

--- a/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
@@ -2,7 +2,8 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { DescriptionListProps } from '../../components/description-list/DescriptionList';
 import { routes } from '../../utils/routes';
-import { ApplicantDashboard } from './Dashboard';
+import { ApplicantDashBoardProps, ApplicantDashboard } from './Dashboard';
+import { getProps } from 'gap-web-ui';
 
 const descriptionList: DescriptionListProps = {
   data: [
@@ -13,30 +14,35 @@ const descriptionList: DescriptionListProps = {
   needBorder: false,
 };
 
-describe('Dashboard', () => {
-  beforeEach(() => {
-    render(
-      <ApplicantDashboard
-        descriptionList={descriptionList}
-        hasApplications={true}
-        oneLoginMatchingAccountBannerEnabled={true}
-      />
-    );
-  });
+function getDefaultProps(): ApplicantDashBoardProps {
+  return {
+    descriptionList: descriptionList,
+    hasApplications: true,
+    oneLoginMatchingAccountBannerEnabled: false,
+  };
+}
 
+describe('Dashboard', () => {
   test('should render 2 <hr/>', () => {
+    render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
+
     const line = screen.getAllByRole('separator');
     expect(line.length).toBe(2);
   });
 
   describe('should render first section', () => {
     test('should render heading', () => {
+      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
+
       const heading = screen.getByRole('heading', {
         name: /your account/i,
       });
       expect(heading).toBeInTheDocument();
     });
+
     test('should render table element', () => {
+      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
+
       const nameKey = screen.getByRole('term', {
         name: /name/i,
       });
@@ -57,6 +63,8 @@ describe('Dashboard', () => {
 
   describe('should render second section', () => {
     test('should render heading', () => {
+      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
+
       const heading = screen.getByRole('heading', {
         name: /view your applications/i,
       });
@@ -64,11 +72,15 @@ describe('Dashboard', () => {
     });
 
     test('should render table element', () => {
+      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
+
       const text = screen.getByText(/see your past and current applications/i);
       expect(text).toBeInTheDocument();
     });
 
     test('should render the link element and have the right href', () => {
+      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
+
       expect(
         screen.getByRole('link', { name: /view your applications/i })
       ).toHaveAttribute('href', '/applications');
@@ -76,17 +88,13 @@ describe('Dashboard', () => {
   });
 
   describe('should render second section when applicant has no applications', () => {
-    beforeEach(() => {
+    test('should render paragraphs', () => {
       render(
         <ApplicantDashboard
-          descriptionList={descriptionList}
-          hasApplications={false}
-          oneLoginMatchingAccountBannerEnabled={true}
+          {...getProps(getDefaultProps, { hasApplications: false })}
         />
       );
-    });
 
-    test('should render paragraphs', () => {
       screen.getByText(/You have not started any applications\./i);
       screen.getByText(
         /To get started, you need to find a grant that you want to apply for\./i
@@ -94,6 +102,12 @@ describe('Dashboard', () => {
     });
 
     test('should find a grant button with correct href', () => {
+      render(
+        <ApplicantDashboard
+          {...getProps(getDefaultProps, { hasApplications: false })}
+        />
+      );
+
       expect(
         screen.getByRole('button', { name: /find a grant/i })
       ).toHaveAttribute('href', routes.findAGrant);
@@ -102,6 +116,12 @@ describe('Dashboard', () => {
 
   describe('should render third section', () => {
     test('should render heading', () => {
+      render(
+        <ApplicantDashboard
+          {...getProps(getDefaultProps, { hasApplications: false })}
+        />
+      );
+
       const heading = screen.getByRole('heading', {
         name: /your details/i,
       });
@@ -109,40 +129,69 @@ describe('Dashboard', () => {
     });
 
     test('should render the 2 cards', () => {
+      render(
+        <ApplicantDashboard
+          {...getProps(getDefaultProps, { hasApplications: false })}
+        />
+      );
+
       const organisationCard = screen.getByText(
         /Change your organisation details/i
       );
       expect(organisationCard).toBeInTheDocument();
     });
   });
-});
 
-describe('migration journey feature flag', () => {
-  test('should render matching account banner', () => {
-    render(
-      <ApplicantDashboard
-        descriptionList={descriptionList}
-        hasApplications={false}
-        oneLoginMatchingAccountBannerEnabled={true}
-      />
-    );
-    const banner = screen.getByRole('heading', {
-      name: 'MATCHING ACCOUNT BANNER PLACEHOLDER',
+  describe('migration journey feature flag', () => {
+    test('Should render the error banner', () => {
+      render(
+        <ApplicantDashboard
+          {...getProps(getDefaultProps, {
+            oneLoginMatchingAccountBannerEnabled: true,
+            migrationSucceeded: 'false',
+          })}
+        />
+      );
+
+      screen.getByRole('heading', { level: 2, name: 'Important' });
+      screen.getByText('Something went wrong while transferring your data.');
+      expect(
+        screen.getByRole('link', {
+          name: 'findagrant@cabinetoffice.gov.uk',
+        })
+      ).toHaveAttribute('href', 'mailto:findagrant@cabinetoffice.gov.uk');
     });
 
-    expect(banner).toBeInTheDocument();
-  });
+    test('Should not render the error banner', () => {
+      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
 
-  test('should not render matching account banner', () => {
-    render(
-      <ApplicantDashboard
-        descriptionList={descriptionList}
-        hasApplications={false}
-        oneLoginMatchingAccountBannerEnabled={false}
-      />
-    );
-    expect(
-      screen.queryByText('MATCHING ACCOUNT BANNER PLACEHOLDER')
-    ).toBeFalsy();
+      expect(
+        screen.queryByRole('heading', { level: 2, name: 'Important' })
+      ).toBeFalsy();
+    });
+
+    test('Should render the success banner', () => {
+      render(
+        <ApplicantDashboard
+          {...getProps(getDefaultProps, {
+            oneLoginMatchingAccountBannerEnabled: true,
+            migrationSucceeded: 'true',
+          })}
+        />
+      );
+
+      screen.getByRole('heading', { level: 2, name: 'Success' });
+      screen.getByText(
+        'Your data has been successfully added to your One Login account.'
+      );
+    });
+
+    test('Should not render the success banner', () => {
+      render(<ApplicantDashboard {...getProps(getDefaultProps)} />);
+
+      expect(
+        screen.queryByRole('heading', { level: 2, name: 'Success' })
+      ).toBeFalsy();
+    });
   });
 });

--- a/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
@@ -18,7 +18,8 @@ function getDefaultProps(): ApplicantDashBoardProps {
   return {
     descriptionList: descriptionList,
     hasApplications: true,
-    oneLoginMatchingAccountBannerEnabled: false,
+    showMigrationErrorBanner: false,
+    showMigrationSuccessBanner: false,
   };
 }
 
@@ -73,8 +74,7 @@ describe('Dashboard', () => {
       render(
         <ApplicantDashboard
           {...getProps(getDefaultProps, {
-            oneLoginMatchingAccountBannerEnabled: true,
-            migrationSucceeded: 'false',
+            showMigrationErrorBanner: true,
           })}
         />
       );
@@ -100,8 +100,7 @@ describe('Dashboard', () => {
       render(
         <ApplicantDashboard
           {...getProps(getDefaultProps, {
-            oneLoginMatchingAccountBannerEnabled: true,
-            migrationSucceeded: 'true',
+            showMigrationSuccessBanner: true,
           })}
         />
       );

--- a/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
@@ -143,7 +143,7 @@ describe('Dashboard', () => {
   });
 
   describe('migration journey feature flag', () => {
-    test('Should render the error banner', () => {
+    test(`renders error banner when migrationSucceeded is 'false'`, () => {
       render(
         <ApplicantDashboard
           {...getProps(getDefaultProps, {

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -28,7 +28,7 @@ export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
           migrationSucceeded === 'true' && (
             <ImportantBanner
               bannerHeading="Your data has been successfully added to your One Login account."
-              successBanner
+              isSuccess
             />
           )}
 

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -6,27 +6,51 @@ import {
   DescriptionListProps,
 } from '../../components/description-list/DescriptionList';
 import { routes } from '../../utils/routes';
+import { ImportantBanner } from 'gap-web-ui';
 
 interface ApplicantDashBoardProps {
   descriptionList: DescriptionListProps;
   hasApplications: boolean;
   oneLoginMatchingAccountBannerEnabled: boolean;
+  migrationSucceeded?: string;
 }
 
 export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
   descriptionList,
   hasApplications,
   oneLoginMatchingAccountBannerEnabled,
+  migrationSucceeded,
 }) => {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
-        {oneLoginMatchingAccountBannerEnabled && (
-          /* TODO: Placeholder for GAP-1923 */
-          <div>
-            <h1>MATCHING ACCOUNT BANNER PLACEHOLDER</h1>
-          </div>
-        )}
+        {oneLoginMatchingAccountBannerEnabled &&
+          migrationSucceeded === 'true' && (
+            <ImportantBanner
+              bannerHeading="Your data has been successfully added to your One Login account."
+              successBanner
+            />
+          )}
+
+        {oneLoginMatchingAccountBannerEnabled &&
+          migrationSucceeded === 'false' && (
+            <ImportantBanner
+              bannerHeading="Something went wrong while transferring your data."
+              bannerContent={
+                <p className="govuk-body">
+                  Please get in contact with our support team at{' '}
+                  <a
+                    className="govuk-notification-banner__link"
+                    href="mailto:findagrant@cabinetoffice.gov.uk"
+                  >
+                    findagrant@cabinetoffice.gov.uk
+                  </a>
+                  {'.'}
+                </p>
+              }
+            />
+          )}
+
         <section>
           <h1
             className="govuk-heading-l"

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -8,12 +8,12 @@ import {
 import { routes } from '../../utils/routes';
 import { ImportantBanner } from 'gap-web-ui';
 
-interface ApplicantDashBoardProps {
+export type ApplicantDashBoardProps = {
   descriptionList: DescriptionListProps;
   hasApplications: boolean;
   oneLoginMatchingAccountBannerEnabled: boolean;
   migrationSucceeded?: string;
-}
+};
 
 export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
   descriptionList,

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -11,45 +11,43 @@ import { ImportantBanner } from 'gap-web-ui';
 export type ApplicantDashBoardProps = {
   descriptionList: DescriptionListProps;
   hasApplications: boolean;
-  oneLoginMatchingAccountBannerEnabled: boolean;
-  migrationSucceeded?: string;
+  showMigrationErrorBanner: boolean;
+  showMigrationSuccessBanner: boolean;
 };
 
 export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
   descriptionList,
   hasApplications,
-  oneLoginMatchingAccountBannerEnabled,
-  migrationSucceeded,
+  showMigrationErrorBanner,
+  showMigrationSuccessBanner,
 }) => {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds">
-        {oneLoginMatchingAccountBannerEnabled &&
-          migrationSucceeded === 'true' && (
-            <ImportantBanner
-              bannerHeading="Your data has been successfully added to your One Login account."
-              isSuccess
-            />
-          )}
+        {showMigrationSuccessBanner && (
+          <ImportantBanner
+            bannerHeading="Your data has been successfully added to your One Login account."
+            isSuccess
+          />
+        )}
 
-        {oneLoginMatchingAccountBannerEnabled &&
-          migrationSucceeded === 'false' && (
-            <ImportantBanner
-              bannerHeading="Something went wrong while transferring your data."
-              bannerContent={
-                <p className="govuk-body">
-                  Please get in contact with our support team at{' '}
-                  <a
-                    className="govuk-notification-banner__link"
-                    href="mailto:findagrant@cabinetoffice.gov.uk"
-                  >
-                    findagrant@cabinetoffice.gov.uk
-                  </a>
-                  {'.'}
-                </p>
-              }
-            />
-          )}
+        {showMigrationErrorBanner && (
+          <ImportantBanner
+            bannerHeading="Something went wrong while transferring your data."
+            bannerContent={
+              <p className="govuk-body">
+                Please get in contact with our support team at{' '}
+                <a
+                  className="govuk-notification-banner__link"
+                  href="mailto:findagrant@cabinetoffice.gov.uk"
+                >
+                  findagrant@cabinetoffice.gov.uk
+                </a>
+                {'.'}
+              </p>
+            }
+          />
+        )}
 
         <section>
           <h1

--- a/packages/applicant/src/pages/dashboard/index.page.test.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.test.tsx
@@ -116,7 +116,7 @@ describe('getServerSideProps', () => {
         descriptionList,
         hasApplications: true,
         oneLoginMatchingAccountBannerEnabled: false,
-        migrationSucceeded: undefined,
+        migrationSucceeded: null,
       },
     });
   });
@@ -147,7 +147,7 @@ describe('getServerSideProps', () => {
         },
         hasApplications: true,
         oneLoginMatchingAccountBannerEnabled: false,
-        migrationSucceeded: undefined,
+        migrationSucceeded: null,
       },
     });
   });

--- a/packages/applicant/src/pages/dashboard/index.page.test.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.test.tsx
@@ -1,40 +1,16 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
 import { GetServerSidePropsContext } from 'next';
-import { RouterContext } from 'next/dist/shared/lib/router-context';
 import { DescriptionListProps } from '../../components/description-list/DescriptionList';
 import { GrantApplicant } from '../../models/GrantApplicant';
 import { getApplicationsListById } from '../../services/ApplicationService';
 import { GrantApplicantService } from '../../services/GrantApplicantService';
-import { createMockRouter } from '../../testUtils/createMockRouter';
 import { getJwtFromCookies } from '../../utils/jwt';
-import ApplicantDashboardPage, {
-  ApplicantDashBoardPageProps,
-  getServerSideProps,
-} from './index.page';
+import { getServerSideProps } from './index.page';
+import { Optional, expectObjectEquals, getContext } from 'gap-web-ui';
 
 jest.mock('../../services/ApplicationService');
 jest.mock('../../utils/jwt');
-jest.mock('next/config', () => () => {
-  return {
-    serverRuntimeConfig: {
-      backendHost: 'http://localhost:8080',
-      subPath: '',
-    },
-    publicRuntimeConfig: {
-      subPath: '',
-    },
-  };
-});
 
-const context = {
-  params: {
-    applicationId: '1',
-  },
-  req: {
-    cookies: {},
-  },
-} as unknown as GetServerSidePropsContext;
 const APPLICANT_ID = '75ab5fbd-0682-4d3d-a467-01c7a447f07c';
 const MOCK_GRANT_APPLICANT: GrantApplicant = {
   id: APPLICANT_ID,
@@ -69,6 +45,7 @@ const MOCK_GRANT_APPLICANT_NO_LEGAL_NAME: GrantApplicant = {
     companiesHouseNumber: '66778899',
   },
 };
+
 const descriptionList: DescriptionListProps = {
   data: [
     { term: 'Email', detail: MOCK_GRANT_APPLICANT.email },
@@ -98,20 +75,23 @@ const MockApplicationsList = [
   },
 ];
 
-const applicantDashboardProps: ApplicantDashBoardPageProps = {
-  descriptionList: descriptionList,
-  hasApplications: true,
-  oneLoginMatchingAccountBannerEnabled: false,
-};
-//TODO once we fetch the Applicant Name and the Organisation Name this test will completely change
 describe('getServerSideProps', () => {
   const env = process.env;
+
+  function getDefaultContext(): Optional<GetServerSidePropsContext> {
+    return {
+      params: {
+        applicationId: '1',
+      },
+    };
+  }
 
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...env };
     process.env.APPLYING_FOR_REDIRECT_COOKIE = 'testRedirectCookie';
   });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -126,16 +106,17 @@ describe('getServerSideProps', () => {
     );
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
 
-    const result = await getServerSideProps(context);
+    const result = await getServerSideProps(getContext(getDefaultContext));
 
     expect(getGrantApplicantSpy).toBeCalledTimes(1);
     expect(getGrantApplicantSpy).toBeCalledWith('testJwt');
 
-    expect(result).toStrictEqual({
+    expectObjectEquals(result, {
       props: {
         descriptionList,
         hasApplications: true,
         oneLoginMatchingAccountBannerEnabled: false,
+        migrationSucceeded: undefined,
       },
     });
   });
@@ -144,13 +125,14 @@ describe('getServerSideProps', () => {
     const getGrantApplicantSpy = jest
       .spyOn(GrantApplicantService.prototype, 'getGrantApplicant')
       .mockResolvedValue(MOCK_GRANT_APPLICANT_NO_LEGAL_NAME);
+
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
-    const result = await getServerSideProps(context);
+    const result = await getServerSideProps(getContext(getDefaultContext));
 
     expect(getGrantApplicantSpy).toBeCalledTimes(1);
     expect(getGrantApplicantSpy).toBeCalledWith('testJwt');
 
-    expect(result).toStrictEqual({
+    expectObjectEquals(result, {
       props: {
         descriptionList: {
           data: [
@@ -165,70 +147,36 @@ describe('getServerSideProps', () => {
         },
         hasApplications: true,
         oneLoginMatchingAccountBannerEnabled: false,
+        migrationSucceeded: undefined,
       },
     });
   });
 
   const mockSetHeader = jest.fn();
-  const contextWithRedirectCookie = {
-    params: {
-      applicationId: '1',
-    },
-    req: {
-      cookies: {
-        testRedirectCookie: 1,
-      },
-    },
-    res: {
-      setHeader: mockSetHeader,
-    },
-  } as unknown as GetServerSidePropsContext;
 
   it('should redirect to applications page', async () => {
-    const result = await getServerSideProps(contextWithRedirectCookie);
+    const result = await getServerSideProps(
+      getContext(getDefaultContext, {
+        req: {
+          cookies: {
+            testRedirectCookie: '1',
+          },
+        },
+        res: {
+          setHeader: mockSetHeader,
+        },
+      })
+    );
 
     expect(mockSetHeader).toBeCalledWith(
       'Set-Cookie',
       'testRedirectCookie=deleted; Path=/; Max-Age=0'
     );
-    expect(result).toStrictEqual({
+    expectObjectEquals(result, {
       redirect: {
         destination: '/applications/1',
         statusCode: 307,
       },
-    });
-  });
-});
-
-describe('ApplicantDashboardPage component', () => {
-  beforeEach(() => {
-    render(
-      <RouterContext.Provider
-        value={createMockRouter({ pathname: '/dashboard' })}
-      >
-        <ApplicantDashboardPage {...applicantDashboardProps} />
-      </RouterContext.Provider>
-    );
-  });
-  describe('should render first section', () => {
-    it('should render heading', () => {
-      screen.getByRole('heading', {
-        name: /your account/i,
-      });
-    });
-    it('should render table email element', () => {
-      screen.getByRole('term', {
-        name: /email/i,
-      });
-      screen.getByText(/test@email.com/i);
-    });
-
-    it('should render table organisation name element', () => {
-      screen.getByRole('term', {
-        name: /organisation/i,
-      });
-
-      screen.getByText(/Boat Service/i);
     });
   });
 });

--- a/packages/applicant/src/pages/dashboard/index.page.test.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.test.tsx
@@ -115,8 +115,8 @@ describe('getServerSideProps', () => {
       props: {
         descriptionList,
         hasApplications: true,
-        oneLoginMatchingAccountBannerEnabled: false,
-        migrationSucceeded: null,
+        showMigrationErrorBanner: false,
+        showMigrationSuccessBanner: false,
       },
     });
   });
@@ -146,8 +146,8 @@ describe('getServerSideProps', () => {
           needBorder: false,
         },
         hasApplications: true,
-        oneLoginMatchingAccountBannerEnabled: false,
-        migrationSucceeded: null,
+        showMigrationErrorBanner: false,
+        showMigrationSuccessBanner: false,
       },
     });
   });

--- a/packages/applicant/src/pages/dashboard/index.page.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.tsx
@@ -52,8 +52,8 @@ export const getServerSideProps = async ({
 
   const oneLoginMatchingAccountBannerEnabled =
     process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED === 'true';
-  const migrationSucceeded = query?.migrationSucceeded as string | undefined;
-
+  const migrationSucceeded =
+    (query?.migrationSucceeded as string | undefined) ?? null;
   return {
     props: {
       descriptionList,

--- a/packages/applicant/src/pages/dashboard/index.page.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.tsx
@@ -12,6 +12,7 @@ import InferProps from '../../types/InferProps';
 export const getServerSideProps = async ({
   req,
   res,
+  query,
 }: GetServerSidePropsContext) => {
   const findRedirectCookie = process.env.APPLYING_FOR_REDIRECT_COOKIE;
 
@@ -51,14 +52,14 @@ export const getServerSideProps = async ({
 
   const oneLoginMatchingAccountBannerEnabled =
     process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED === 'true';
+  const migrationSucceeded = query?.migrationSucceeded as string | undefined;
 
   return {
     props: {
       descriptionList,
       hasApplications,
-      oneLoginMatchingAccountBannerEnabled: Boolean(
-        oneLoginMatchingAccountBannerEnabled
-      ),
+      oneLoginMatchingAccountBannerEnabled,
+      migrationSucceeded,
     },
   };
 };
@@ -67,6 +68,7 @@ export default function ApplicantDashboardPage({
   descriptionList,
   hasApplications,
   oneLoginMatchingAccountBannerEnabled,
+  migrationSucceeded,
 }: InferProps<typeof getServerSideProps>) {
   return (
     <>
@@ -78,6 +80,7 @@ export default function ApplicantDashboardPage({
           oneLoginMatchingAccountBannerEnabled={
             oneLoginMatchingAccountBannerEnabled
           }
+          migrationSucceeded={migrationSucceeded}
         />
       </Layout>
     </>

--- a/packages/applicant/src/pages/dashboard/index.page.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.tsx
@@ -52,14 +52,17 @@ export const getServerSideProps = async ({
 
   const oneLoginMatchingAccountBannerEnabled =
     process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED === 'true';
-  const migrationSucceeded =
-    (query?.migrationSucceeded as string | undefined) ?? null;
+  const migrationStatus = query?.migrationStatus ?? null;
+  const showMigrationSuccessBanner =
+    oneLoginMatchingAccountBannerEnabled && migrationStatus === 'success';
+  const showMigrationErrorBanner =
+    oneLoginMatchingAccountBannerEnabled && migrationStatus === 'error';
   return {
     props: {
       descriptionList,
       hasApplications,
-      oneLoginMatchingAccountBannerEnabled,
-      migrationSucceeded,
+      showMigrationErrorBanner,
+      showMigrationSuccessBanner,
     },
   };
 };
@@ -67,8 +70,8 @@ export const getServerSideProps = async ({
 export default function ApplicantDashboardPage({
   descriptionList,
   hasApplications,
-  oneLoginMatchingAccountBannerEnabled,
-  migrationSucceeded,
+  showMigrationErrorBanner,
+  showMigrationSuccessBanner,
 }: InferProps<typeof getServerSideProps>) {
   return (
     <>
@@ -77,10 +80,8 @@ export default function ApplicantDashboardPage({
         <ApplicantDashboard
           descriptionList={descriptionList}
           hasApplications={hasApplications}
-          oneLoginMatchingAccountBannerEnabled={
-            oneLoginMatchingAccountBannerEnabled
-          }
-          migrationSucceeded={migrationSucceeded}
+          showMigrationErrorBanner={showMigrationErrorBanner}
+          showMigrationSuccessBanner={showMigrationSuccessBanner}
         />
       </Layout>
     </>

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.stories.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.stories.tsx
@@ -12,7 +12,29 @@ const Template: ComponentStory<typeof ImportantBanner> = (args) => (
 );
 
 export const importantBanner = Template.bind({});
-
 importantBanner.args = {
   bannerHeading: 'This is some important banner content',
+};
+
+export const successBanner = Template.bind({});
+successBanner.args = {
+  bannerHeading: 'This is some success banner content',
+  successBanner: true,
+};
+
+export const importantBannerWithEmail = Template.bind({});
+importantBannerWithEmail.args = {
+  bannerHeading: 'This is some important banner content',
+  bannerContent: (
+    <p className="govuk-body">
+      Please get in contact with our support team at{' '}
+      <a
+        className="govuk-notification-banner__link"
+        href="mailto:findagrant@cabinetoffice.gov.uk"
+      >
+        findagrant@cabinetoffice.gov.uk
+      </a>
+      {'.'}
+    </p>
+  ),
 };

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.stories.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.stories.tsx
@@ -19,7 +19,7 @@ importantBanner.args = {
 export const successBanner = Template.bind({});
 successBanner.args = {
   bannerHeading: 'This is some success banner content',
-  successBanner: true,
+  isSuccess: true,
 };
 
 export const importantBannerWithEmail = Template.bind({});

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.stories.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ImportantBanner from './ImportantBanner';
 
 export default {
-  title: 'gap-web-ui/ImportnantBanner',
+  title: 'gap-web-ui/ImportantBanner',
   component: ImportantBanner,
 } as ComponentMeta<typeof ImportantBanner>;
 
@@ -14,5 +14,5 @@ const Template: ComponentStory<typeof ImportantBanner> = (args) => (
 export const importantBanner = Template.bind({});
 
 importantBanner.args = {
-  bannerContent: 'This is some important banner content',
+  bannerHeading: 'This is some important banner content',
 };

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.test.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import ImportantBanner, { ImportantBannerProps } from './ImportantBanner';
 import React from 'react';
 
-const props: ImportantBannerProps = { bannerContent: 'Banner content text' };
+const props: ImportantBannerProps = { bannerHeading: 'Banner content text' };
 const ImportantBannerComponent = () => {
   render(<ImportantBanner {...props} />);
 };

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.test.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.test.tsx
@@ -29,9 +29,7 @@ describe('Important Banner Component', () => {
 
   it('Should render success banner', () => {
     render(
-      <ImportantBanner
-        {...getProps(getDefaultProps, { successBanner: true })}
-      />
+      <ImportantBanner {...getProps(getDefaultProps, { isSuccess: true })} />
     );
 
     expect(

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.test.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.test.tsx
@@ -2,24 +2,50 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ImportantBanner, { ImportantBannerProps } from './ImportantBanner';
 import React from 'react';
+import { getProps } from '../../utils';
 
-const props: ImportantBannerProps = { bannerHeading: 'Banner content text' };
-const ImportantBannerComponent = () => {
-  render(<ImportantBanner {...props} />);
-};
 describe('Important Banner Component', () => {
-  beforeEach(() => {
-    ImportantBannerComponent();
-  });
+  function getDefaultProps(): ImportantBannerProps {
+    return {
+      bannerHeading: 'Banner content text',
+    };
+  }
+
   it('Should render banner content when provided', () => {
+    render(<ImportantBanner {...getProps(getDefaultProps)} />);
+
     expect(screen.getByText('Banner content text')).toHaveClass(
       'govuk-notification-banner__heading'
     );
   });
 
   it('Should render banner heading', () => {
+    render(<ImportantBanner {...getProps(getDefaultProps)} />);
+
     expect(
       screen.getByRole('heading', { level: 2, name: 'Important' })
     ).toHaveClass('govuk-notification-banner__title');
+  });
+
+  it('Should render success banner', () => {
+    render(
+      <ImportantBanner
+        {...getProps(getDefaultProps, { successBanner: true })}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Success' })
+    ).toHaveClass('govuk-notification-banner__title');
+  });
+
+  it('Should render banner content', () => {
+    render(
+      <ImportantBanner
+        {...getProps(getDefaultProps, { bannerContent: 'Banner content' })}
+      />
+    );
+
+    screen.getByText('Banner content');
   });
 });

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
@@ -6,11 +6,17 @@ import React from 'react';
  * if this component needs to use more than a single line,
  *  it is recommended to restructure it to use a h3 and a p tag
  */
-const ImportantBanner = ({ bannerContent }: ImportantBannerProps) => {
+const ImportantBanner = ({
+  bannerHeading,
+  bannerContent,
+  successBanner = false,
+}: ImportantBannerProps) => {
   return (
     <div
-      className="govuk-notification-banner"
-      role="region"
+      className={`govuk-notification-banner ${
+        successBanner ? 'govuk-notification-banner--success' : ''
+      }`}
+      role={successBanner ? 'alert' : 'region'}
       aria-labelledby="govuk-notification-banner-title"
       data-module="govuk-notification-banner"
     >
@@ -20,7 +26,7 @@ const ImportantBanner = ({ bannerContent }: ImportantBannerProps) => {
           id="govuk-notification-banner-title"
           data-cy="cyImportantBannerTitle"
         >
-          Important
+          {successBanner ? 'Success' : 'Important'}
         </h2>
       </div>
       <div className="govuk-notification-banner__content">
@@ -28,15 +34,24 @@ const ImportantBanner = ({ bannerContent }: ImportantBannerProps) => {
           className="govuk-notification-banner__heading"
           data-cy="cyImportantBannerBody"
         >
-          {bannerContent}
+          {bannerHeading}
         </p>
+
+        {bannerContent &&
+          (typeof bannerContent === 'string' ? (
+            <p className="govuk-body">{bannerContent}</p>
+          ) : (
+            bannerContent
+          ))}
       </div>
     </div>
   );
 };
 
 export interface ImportantBannerProps {
-  bannerContent: string;
+  bannerHeading: string;
+  bannerContent?: JSX.Element | string;
+  successBanner?: boolean;
 }
 
 export default ImportantBanner;

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 
 /**
  * Generic component to be used when adding a GDS important notification banner.
- * Currently we provide bannerContent prop for single line notifications,
- * if this component needs to use more than a single line,
- *  it is recommended to restructure it to use a h3 and a p tag
  */
 const ImportantBanner = ({
   bannerHeading,

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
@@ -45,10 +45,10 @@ const ImportantBanner = ({
   );
 };
 
-export interface ImportantBannerProps {
+export type ImportantBannerProps = {
   bannerHeading: string;
   bannerContent?: JSX.Element | string;
   successBanner?: boolean;
-}
+};
 
 export default ImportantBanner;

--- a/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
+++ b/packages/gap-web-ui/src/components/notification-banner/ImportantBanner.tsx
@@ -6,14 +6,14 @@ import React from 'react';
 const ImportantBanner = ({
   bannerHeading,
   bannerContent,
-  successBanner = false,
+  isSuccess = false,
 }: ImportantBannerProps) => {
   return (
     <div
       className={`govuk-notification-banner ${
-        successBanner ? 'govuk-notification-banner--success' : ''
+        isSuccess ? 'govuk-notification-banner--success' : ''
       }`}
-      role={successBanner ? 'alert' : 'region'}
+      role={isSuccess ? 'alert' : 'region'}
       aria-labelledby="govuk-notification-banner-title"
       data-module="govuk-notification-banner"
     >
@@ -23,7 +23,7 @@ const ImportantBanner = ({
           id="govuk-notification-banner-title"
           data-cy="cyImportantBannerTitle"
         >
-          {successBanner ? 'Success' : 'Important'}
+          {isSuccess ? 'Success' : 'Important'}
         </h2>
       </div>
       <div className="govuk-notification-banner__content">
@@ -48,7 +48,7 @@ const ImportantBanner = ({
 export type ImportantBannerProps = {
   bannerHeading: string;
   bannerContent?: JSX.Element | string;
-  successBanner?: boolean;
+  isSuccess?: boolean;
 };
 
 export default ImportantBanner;

--- a/packages/gap-web-ui/src/utils/UnitTestHelpers.tsx
+++ b/packages/gap-web-ui/src/utils/UnitTestHelpers.tsx
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { isArray, merge, mergeWith } from 'lodash';
 import { GetServerSidePropsContext } from 'next';
 import { render } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
@@ -14,7 +14,9 @@ const getProps = <T extends Record<string, unknown>>(
   defaultProps: () => T,
   overrides: Optional<T> = {}
 ) => {
-  return merge(defaultProps(), overrides) as T;
+  return mergeWith(defaultProps(), overrides, (obj, src) =>
+    isArray(src) ? src : undefined
+  ) as T;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,6 +5921,9 @@ __metadata:
     cypress-recurse: ^1.18.0
     date-fns: ^2.19.0
     dotenv: ^16.0.0
+    eslint: 8.42.0
+    eslint-config-next: 12.0.7
+    eslint-config-prettier: ^8.5.0
     form-data: ^4.0.0
     formidable: 2.1.0
     gap-web-ui: "*"


### PR DESCRIPTION
Upon logging in for the first time, users with COLA subs are migrated in the backend. A query param is sent up to the frontend which determines what banner to show. Upon subsequent logins, they will not see this banner.

Admin failed to migrate:
<img width="1022" alt="Screenshot 2023-08-04 at 16 36 03" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/358a5152-34e6-4a06-bac9-acf3ffe0e393">


Admin successfully migrated:
<img width="1059" alt="Screenshot 2023-08-04 at 16 36 37" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/2aaa1939-18f7-4b4d-8e1d-4788c00ff71d">


Banner storybooks:
<img width="1056" alt="Screenshot 2023-08-04 at 14 51 40" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/aa00e93e-4533-48a5-a5e5-8385f32e6437">
