### PR TITLE
GAP-1927: [Applicant] - Edit log in details

### DIFF
--- a/packages/applicant/.env.example
+++ b/packages/applicant/.env.example
@@ -16,3 +16,4 @@ V2_LOGIN_URL=http://localhost:8082/v2/login?redirectUrl=http://localhost:3000/ap
 V2_LOGOUT_URL=http://localhost:8082/v2/logout
 JWT_COOKIE_NAME=user-service-token
 ONE_LOGIN_MIGRATION_JOURNEY_ENABLED=false
+ONE_LOGIN_URL=https://home.integration.account.gov.uk/security

--- a/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
@@ -126,10 +126,9 @@ describe('OneLogin feature flag', () => {
   test('should render Sign In Details card when OneLogin feature flag is enabled', () => {
     render(
       <ApplicantDashboard
-        descriptionList={descriptionList}
-        hasApplications={false}
-        oneLoginMatchingAccountBannerEnabled={true}
-        oneLoginEnabled={true}
+        {...getProps(getDefaultProps, {
+          oneLoginEnabled: true,
+        })}
       />
     );
     const card = screen.getByRole('link', {
@@ -142,10 +141,9 @@ describe('OneLogin feature flag', () => {
   test('should not render Sign In Details card when OneLogin feature flag is disabled', () => {
     render(
       <ApplicantDashboard
-        descriptionList={descriptionList}
-        hasApplications={false}
-        oneLoginMatchingAccountBannerEnabled={false}
-        oneLoginEnabled={false}
+        {...getProps(getDefaultProps, {
+          oneLoginEnabled: false,
+        })}
       />
     );
     expect(screen.queryByText('Your sign in details')).toBeFalsy();

--- a/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.test.tsx
@@ -20,6 +20,7 @@ describe('Dashboard', () => {
         descriptionList={descriptionList}
         hasApplications={true}
         oneLoginMatchingAccountBannerEnabled={true}
+        oneLoginEnabled={true}
       />
     );
   });
@@ -82,6 +83,7 @@ describe('Dashboard', () => {
           descriptionList={descriptionList}
           hasApplications={false}
           oneLoginMatchingAccountBannerEnabled={true}
+          oneLoginEnabled={true}
         />
       );
     });
@@ -124,6 +126,7 @@ describe('migration journey feature flag', () => {
         descriptionList={descriptionList}
         hasApplications={false}
         oneLoginMatchingAccountBannerEnabled={true}
+        oneLoginEnabled={true}
       />
     );
     const banner = screen.getByRole('heading', {
@@ -139,10 +142,41 @@ describe('migration journey feature flag', () => {
         descriptionList={descriptionList}
         hasApplications={false}
         oneLoginMatchingAccountBannerEnabled={false}
+        oneLoginEnabled={true}
       />
     );
     expect(
       screen.queryByText('MATCHING ACCOUNT BANNER PLACEHOLDER')
     ).toBeFalsy();
+  });
+});
+
+describe('OneLogin feature flag', () => {
+  test('should render Sign In Details card when OneLogin feature flag is enabled', () => {
+    render(
+      <ApplicantDashboard
+        descriptionList={descriptionList}
+        hasApplications={false}
+        oneLoginMatchingAccountBannerEnabled={true}
+        oneLoginEnabled={true}
+      />
+    );
+    const card = screen.getByRole('link', {
+      name: 'Your sign in details',
+    });
+
+    expect(card).toBeInTheDocument();
+  });
+
+  test('should not render Sign In Details card when OneLogin feature flag is disabled', () => {
+    render(
+      <ApplicantDashboard
+        descriptionList={descriptionList}
+        hasApplications={false}
+        oneLoginMatchingAccountBannerEnabled={false}
+        oneLoginEnabled={false}
+      />
+    );
+    expect(screen.queryByText('Your sign in details')).toBeFalsy();
   });
 });

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -6,17 +6,22 @@ import {
   DescriptionListProps,
 } from '../../components/description-list/DescriptionList';
 import { routes } from '../../utils/routes';
+import getConfig from 'next/config';
 
 interface ApplicantDashBoardProps {
   descriptionList: DescriptionListProps;
   hasApplications: boolean;
   oneLoginMatchingAccountBannerEnabled: boolean;
+  oneLoginEnabled: boolean;
 }
+
+const { publicRuntimeConfig } = getConfig();
 
 export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
   descriptionList,
   hasApplications,
   oneLoginMatchingAccountBannerEnabled,
+  oneLoginEnabled,
 }) => {
   return (
     <div className="govuk-grid-row">
@@ -105,6 +110,13 @@ export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
               linkDescription={'Your organisation details'}
               description={'Change your organisation details'}
             />
+            {oneLoginEnabled && (
+              <Card
+                link={routes.signInDetails}
+                linkDescription={'Your sign in details'}
+                description={'Change your sign in details'}
+              />
+            )}
           </div>
         </section>
       </div>

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -7,7 +7,6 @@ import {
 } from '../../components/description-list/DescriptionList';
 import { routes } from '../../utils/routes';
 import { ImportantBanner } from 'gap-web-ui';
-import getConfig from 'next/config';
 
 export type ApplicantDashBoardProps = {
   descriptionList: DescriptionListProps;
@@ -16,8 +15,6 @@ export type ApplicantDashBoardProps = {
   showMigrationSuccessBanner: boolean;
   oneLoginEnabled: boolean;
 };
-
-const { publicRuntimeConfig } = getConfig();
 
 export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
   descriptionList,

--- a/packages/applicant/src/pages/dashboard/index.page.test.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.test.tsx
@@ -117,7 +117,7 @@ describe('getServerSideProps', () => {
         hasApplications: true,
         showMigrationErrorBanner: false,
         showMigrationSuccessBanner: false,
-        oneLoginEnabled: true,
+        oneLoginEnabled: false,
       },
     });
   });
@@ -149,7 +149,7 @@ describe('getServerSideProps', () => {
         hasApplications: true,
         showMigrationErrorBanner: false,
         showMigrationSuccessBanner: false,
-        oneLoginEnabled: true,
+        oneLoginEnabled: false,
       },
     });
   });

--- a/packages/applicant/src/pages/dashboard/index.page.test.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.test.tsx
@@ -8,10 +8,7 @@ import { getApplicationsListById } from '../../services/ApplicationService';
 import { GrantApplicantService } from '../../services/GrantApplicantService';
 import { createMockRouter } from '../../testUtils/createMockRouter';
 import { getJwtFromCookies } from '../../utils/jwt';
-import ApplicantDashboardPage, {
-  ApplicantDashBoardPageProps,
-  getServerSideProps,
-} from './index.page';
+import ApplicantDashboardPage, { getServerSideProps } from './index.page';
 
 jest.mock('../../services/ApplicationService');
 jest.mock('../../utils/jwt');
@@ -98,10 +95,11 @@ const MockApplicationsList = [
   },
 ];
 
-const applicantDashboardProps: ApplicantDashBoardPageProps = {
+const applicantDashboardProps = {
   descriptionList: descriptionList,
   hasApplications: true,
   oneLoginMatchingAccountBannerEnabled: false,
+  oneLoginEnabled: true,
 };
 //TODO once we fetch the Applicant Name and the Organisation Name this test will completely change
 describe('getServerSideProps', () => {
@@ -136,6 +134,7 @@ describe('getServerSideProps', () => {
         descriptionList,
         hasApplications: true,
         oneLoginMatchingAccountBannerEnabled: false,
+        oneLoginEnabled: true,
       },
     });
   });
@@ -165,6 +164,7 @@ describe('getServerSideProps', () => {
         },
         hasApplications: true,
         oneLoginMatchingAccountBannerEnabled: false,
+        oneLoginEnabled: true,
       },
     });
   });

--- a/packages/applicant/src/pages/dashboard/index.page.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.tsx
@@ -57,7 +57,6 @@ export const getServerSideProps = async ({
     oneLoginMatchingAccountBannerEnabled && migrationStatus === 'success';
   const showMigrationErrorBanner =
     oneLoginMatchingAccountBannerEnabled && migrationStatus === 'error';
-
   const oneLoginEnabled = process.env.ONE_LOGIN_ENABLED === 'true';
 
   return {

--- a/packages/applicant/src/pages/dashboard/index.page.tsx
+++ b/packages/applicant/src/pages/dashboard/index.page.tsx
@@ -52,13 +52,15 @@ export const getServerSideProps = async ({
   const oneLoginMatchingAccountBannerEnabled =
     process.env.ONE_LOGIN_MIGRATION_JOURNEY_ENABLED === 'true';
 
+  const oneLoginEnabled = process.env.ONE_LOGIN_ENABLED === 'true';
+
   return {
     props: {
       descriptionList,
       hasApplications,
-      oneLoginMatchingAccountBannerEnabled: Boolean(
-        oneLoginMatchingAccountBannerEnabled
-      ),
+      oneLoginMatchingAccountBannerEnabled:
+        oneLoginMatchingAccountBannerEnabled,
+      oneLoginEnabled: oneLoginEnabled,
     },
   };
 };
@@ -67,6 +69,7 @@ export default function ApplicantDashboardPage({
   descriptionList,
   hasApplications,
   oneLoginMatchingAccountBannerEnabled,
+  oneLoginEnabled,
 }: InferProps<typeof getServerSideProps>) {
   return (
     <>
@@ -78,6 +81,7 @@ export default function ApplicantDashboardPage({
           oneLoginMatchingAccountBannerEnabled={
             oneLoginMatchingAccountBannerEnabled
           }
+          oneLoginEnabled={oneLoginEnabled}
         />
       </Layout>
     </>

--- a/packages/applicant/src/pages/sign-in-details/index.page.test.tsx
+++ b/packages/applicant/src/pages/sign-in-details/index.page.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+import { createMockRouter } from '../../testUtils/createMockRouter';
+import SignInDetails from './index.page';
+
+describe('Sign in details page', () => {
+  beforeEach(() => {
+    render(
+      <RouterContext.Provider
+        value={createMockRouter({ pathname: '/sign-in-details' })}
+      >
+        <SignInDetails />
+      </RouterContext.Provider>
+    );
+  });
+  it('should render heading', () => {
+    screen.getByRole('heading', {
+      name: /Your sign in details/i,
+    });
+  });
+
+  it('should render first paragraph', () => {
+    screen.getByText(
+      /You use your GOV\.UK One Login to sign in to Find a grant\./i
+    );
+  });
+  it('should render second paragraph', () => {
+    screen.getByText(
+      /You can change these details in your GOV\.UK One Login:/i
+    );
+  });
+
+  it('should render OneLogin link', () => {
+    expect(
+      screen.getByRole('link', {
+        name: /Change your sign in details in your GOV\.UK One Login/i,
+      })
+    ).toHaveAttribute(
+      'href',
+      `https://home.integration.account.gov.uk/security`
+    );
+  });
+});

--- a/packages/applicant/src/pages/sign-in-details/index.page.tsx
+++ b/packages/applicant/src/pages/sign-in-details/index.page.tsx
@@ -4,7 +4,7 @@ import Layout from '../../components/partials/Layout';
 import Meta from '../../components/partials/Meta';
 
 const SignInDetails = () => {
-  const oneLoginURL = 'https://home.integration.account.gov.uk/security';
+  const oneLoginURL = process.env.ONE_LOGIN_URL;
   return (
     <>
       <Meta title="Your sign in details - Apply for a grant" />

--- a/packages/applicant/src/pages/sign-in-details/index.page.tsx
+++ b/packages/applicant/src/pages/sign-in-details/index.page.tsx
@@ -25,10 +25,12 @@ const SignInDetails = () => {
             </p>
             <p className="govuk-body">
               You can change these details in your GOV.UK One Login:
+            </p>
+            <ul className="govuk-body">
               <li>email address</li>
               <li>password</li>
               <li>how you get security codes to sign in</li>
-            </p>
+            </ul>
             <p className="govuk-body">
               <a href={oneLoginURL}>
                 Change your sign in details in your GOV.UK One Login

--- a/packages/applicant/src/pages/sign-in-details/index.page.tsx
+++ b/packages/applicant/src/pages/sign-in-details/index.page.tsx
@@ -1,0 +1,44 @@
+import getConfig from 'next/config';
+
+import Layout from '../../components/partials/Layout';
+import Meta from '../../components/partials/Meta';
+
+const SignInDetails = () => {
+  const oneLoginURL = 'https://home.integration.account.gov.uk/security';
+  return (
+    <>
+      <Meta title="Your sign in details - Apply for a grant" />
+
+      <Layout>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <h1
+              className="govuk-heading-l"
+              id="main-content-focus"
+              tabIndex={-1}
+              data-cy="cy-sign-in-details-header"
+            >
+              Your sign in details
+            </h1>
+            <p className="govuk-body">
+              You use your GOV.UK One Login to sign in to Find a grant.
+            </p>
+            <p className="govuk-body">
+              You can change these details in your GOV.UK One Login:
+              <li>email address</li>
+              <li>password</li>
+              <li>how you get security codes to sign in</li>
+            </p>
+            <p className="govuk-body">
+              <a href={oneLoginURL}>
+                Change your sign in details in your GOV.UK One Login
+              </a>
+            </p>
+          </div>
+        </div>
+      </Layout>
+    </>
+  );
+};
+
+export default SignInDetails;

--- a/packages/applicant/src/utils/routes.tsx
+++ b/packages/applicant/src/utils/routes.tsx
@@ -7,6 +7,7 @@ export const routes = {
   dashboard: '/dashboard',
   grants: '/grants',
   personalDetails: '/personal-details',
+  signInDetails: '/sign-in-details',
   organisation: {
     index: '/organisation',
     address: '/organisation/address',


### PR DESCRIPTION
<img width="997" alt="Screenshot 2023-08-08 at 15 54 50" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/107405237/7bc6d334-b6cf-46d6-a15c-f5f53a8d050e">

Adds a new 'Change your sign in details' card to the Applicant dashboard when the OneLogin feature flag is enabled.



<img width="1079" alt="Screenshot 2023-08-08 at 15 55 52" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/107405237/26929569-e491-4a7c-ab1d-0927b28d604a">

Adds a OneLogin information screen 9behind a OneLogin feature flag) and a offsite link to OneLogin.  
