### PR TITLE
Add TechnicalSupport navigation bar item

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -8,6 +8,7 @@ on:
       - GAP-**
       - fix/**
       - bug/**
+      - TMI2-**
     paths-ignore:
       - "*.md"
 

--- a/packages/admin/next.config.js
+++ b/packages/admin/next.config.js
@@ -28,5 +28,6 @@ module.exports = {
       process.env.FIND_A_GRANT_URL ||
       'https://www.find-government-grants.service.gov.uk',
     oneLoginEnabled: process.env.ONE_LOGIN_ENABLED === 'true',
+    TECHNICAL_SUPPORT_DOMAIN: process.env.TECHNICAL_SUPPORT_DOMAIN,
   },
 };

--- a/packages/admin/setupJestMock.js
+++ b/packages/admin/setupJestMock.js
@@ -16,6 +16,7 @@ jest.mock('next/config', () => {
         SUB_PATH: '/apply',
         APPLICANT_DOMAIN: 'http://localhost:3000',
         FIND_A_GRANT_URL: 'https://www.find-government-grants.service.gov.uk',
+        TECHNICAL_SUPPORT_DOMAIN: 'mocked-technical-support-domain',
       },
       serverRuntimeConfig: {
         backendHost: 'http://localhost:8080',

--- a/packages/admin/src/pages/super-admin-dashboard/Navigation.test.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/Navigation.test.tsx
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import Navigation from './Navigation';
+import { Role } from './types';
+
+jest.mock('next/config', () => () => ({
+  publicRuntimeConfig: {
+    FIND_A_GRANT_URL: 'mocked-find-a-grant-url',
+    APPLICANT_DOMAIN: 'mocked-applicant-domain',
+    TECHNICAL_SUPPORT_DOMAIN: 'mocked-technical-support-domain',
+  },
+}));
+
+const roles: Role[] = [
+  { name: 'ADMIN', id: '1', description: 'adminRole', label: 'adminLabel' },
+  {
+    name: 'TECHNICAL_SUPPORT',
+    id: '2',
+    description: 'technicalSupportRole',
+    label: 'technicalSupportLabel',
+  },
+];
+
+describe('Navigation', () => {
+  it('renders navigation items correctly when TECHNICAL_SUPPORT role is present in the roles', () => {
+    const { getByText } = render(<Navigation roles={roles} />);
+
+    expect(getByText('Home')).toBeInTheDocument();
+    expect(getByText('Manage users')).toBeInTheDocument();
+    expect(getByText('Admin dashboard')).toBeInTheDocument();
+    expect(getByText('Applicant dashboard')).toBeInTheDocument();
+    expect(getByText('Technical Support dashboard')).toBeInTheDocument();
+  });
+
+  it('does not render "Technical Support dashboard" link for non-TECHNICAL_SUPPORT roles', () => {
+    const { queryByText } = render(<Navigation roles={roles.slice(0, 1)} />);
+
+    const technicalSupportDashboardLink = queryByText(
+      'Technical Support dashboard'
+    );
+    expect(technicalSupportDashboardLink).toBeNull();
+  });
+});

--- a/packages/admin/src/pages/super-admin-dashboard/Navigation.test.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/Navigation.test.tsx
@@ -3,14 +3,6 @@ import { render } from '@testing-library/react';
 import Navigation from './Navigation';
 import { Role } from './types';
 
-jest.mock('next/config', () => () => ({
-  publicRuntimeConfig: {
-    FIND_A_GRANT_URL: 'mocked-find-a-grant-url',
-    APPLICANT_DOMAIN: 'mocked-applicant-domain',
-    TECHNICAL_SUPPORT_DOMAIN: 'mocked-technical-support-domain',
-  },
-}));
-
 const roles: Role[] = [
   { name: 'ADMIN', id: '1', description: 'adminRole', label: 'adminLabel' },
   {
@@ -23,13 +15,13 @@ const roles: Role[] = [
 
 describe('Navigation', () => {
   it('renders navigation items correctly when TECHNICAL_SUPPORT role is present in the roles', () => {
-    const { getByText } = render(<Navigation roles={roles} />);
+    const { getByRole } = render(<Navigation roles={roles} />);
 
-    expect(getByText('Home')).toBeInTheDocument();
-    expect(getByText('Manage users')).toBeInTheDocument();
-    expect(getByText('Admin dashboard')).toBeInTheDocument();
-    expect(getByText('Applicant dashboard')).toBeInTheDocument();
-    expect(getByText('Manage API Keys')).toBeInTheDocument();
+    expect(getByRole('link', { name: 'Home' })).toBeVisible();
+    expect(getByRole('link', { name: 'Manage users' })).toBeVisible();
+    expect(getByRole('link', { name: 'Admin dashboard' })).toBeVisible();
+    expect(getByRole('link', { name: 'Applicant dashboard' })).toBeVisible();
+    expect(getByRole('link', { name: 'Manage API Keys' })).toBeVisible();
   });
 
   it('does not render "Manage API Keys" link for non-TECHNICAL_SUPPORT roles', () => {

--- a/packages/admin/src/pages/super-admin-dashboard/Navigation.test.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/Navigation.test.tsx
@@ -29,15 +29,13 @@ describe('Navigation', () => {
     expect(getByText('Manage users')).toBeInTheDocument();
     expect(getByText('Admin dashboard')).toBeInTheDocument();
     expect(getByText('Applicant dashboard')).toBeInTheDocument();
-    expect(getByText('Technical Support dashboard')).toBeInTheDocument();
+    expect(getByText('Manage API Keys')).toBeInTheDocument();
   });
 
-  it('does not render "Technical Support dashboard" link for non-TECHNICAL_SUPPORT roles', () => {
+  it('does not render "Manage API Keys" link for non-TECHNICAL_SUPPORT roles', () => {
     const { queryByText } = render(<Navigation roles={roles.slice(0, 1)} />);
 
-    const technicalSupportDashboardLink = queryByText(
-      'Technical Support dashboard'
-    );
+    const technicalSupportDashboardLink = queryByText('Manage API Keys');
     expect(technicalSupportDashboardLink).toBeNull();
   });
 });

--- a/packages/admin/src/pages/super-admin-dashboard/Navigation.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/Navigation.tsx
@@ -34,7 +34,7 @@ const Navigation = ({ roles }: NavigationProps) => {
   const technicalSupportNavItem = {
     pageId: 'technicalDash',
     href: publicRuntimeConfig.TECHNICAL_SUPPORT_DOMAIN + '/api-keys',
-    title: 'Technical Support dashboard',
+    title: 'Manage API Keys',
   };
 
   if (roles.find((role) => role.name === 'TECHNICAL_SUPPORT')) {

--- a/packages/admin/src/pages/super-admin-dashboard/Navigation.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/Navigation.tsx
@@ -1,7 +1,12 @@
-import Link from 'next/link';
 import getConfig from 'next/config';
+import Link from 'next/link';
+import { Role } from './types';
 
-const Navigation = () => {
+interface NavigationProps {
+  roles: Role[];
+}
+
+const Navigation = ({ roles }: NavigationProps) => {
   const { publicRuntimeConfig } = getConfig();
   const navItems = [
     {
@@ -25,6 +30,16 @@ const Navigation = () => {
       title: 'Applicant dashboard',
     },
   ];
+
+  const technicalSupportNavItem = {
+    pageId: 'technicalDash',
+    href: publicRuntimeConfig.TECHNICAL_SUPPORT_DOMAIN + '/api-keys',
+    title: 'Technical Support dashboard',
+  };
+
+  if (roles.find((role) => role.name === 'TECHNICAL_SUPPORT')) {
+    navItems.push(technicalSupportNavItem);
+  }
 
   // Build the links in the main navigation && set active states
   return (

--- a/packages/admin/src/pages/super-admin-dashboard/index.page.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/index.page.tsx
@@ -1,15 +1,15 @@
+import { Button, Checkboxes, Table } from 'gap-web-ui';
 import { GetServerSidePropsContext } from 'next';
 import Link from 'next/link';
-import { Button, Checkboxes, Table } from 'gap-web-ui';
 import Meta from '../../components/layout/Meta';
+import { Pagination } from '../../components/pagination/Pagination';
+import { getSuperAdminDashboard } from '../../services/SuperAdminService';
+import InferProps from '../../types/InferProps';
 import PaginationType from '../../types/Pagination';
 import { getUserTokenFromCookies } from '../../utils/session';
-import { Pagination } from '../../components/pagination/Pagination';
+import Navigation from './Navigation';
 import styles from './superadmin-dashboard.module.scss';
-import { getSuperAdminDashboard } from '../../services/SuperAdminService';
 import { User } from './types';
-import Navigation from './Nagivation';
-import InferProps from '../../types/InferProps';
 
 export const getServerSideProps = async ({
   req,
@@ -61,7 +61,7 @@ const SuperAdminDashboard = ({
 }: InferProps<typeof getServerSideProps>) => {
   return (
     <>
-      <Navigation />
+      <Navigation roles={roles} />
       <div className="govuk-grid-row govuk-!-padding-top-2">
         <Meta title="Manage Users" />
         <div className="govuk-width-container">


### PR DESCRIPTION
Adds a new navigation bar item for user that have TECHNICAL_SUPPORT role.
this item will not be shown otherwise.