### PR TITLE
GAP-2088 (redirects)

### DIFF
--- a/packages/admin/src/pages/super-admin-dashboard/index.page.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/index.page.tsx
@@ -17,6 +17,7 @@ import { getUserTokenFromCookies } from '../../utils/session';
 import Navigation from './Navigation';
 import styles from './superadmin-dashboard.module.scss';
 import { SuperAdminDashboardFilterData, User } from './types';
+import { getRedirect } from '../../utils/fetchDataOrGetRedirect';
 
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
@@ -58,6 +59,7 @@ export const getServerSideProps = async (
     fetchPageData,
     handleRequest,
     jwt: getUserTokenFromCookies(req),
+    fetchPageDataErrorHandler: (err: unknown) => getRedirect(err),
     onErrorMessage: 'Failed to filter users, please try again later.',
     onSuccessRedirectHref: (body) => {
       if ('clear-all-filters' in body) return `/super-admin-dashboard`;

--- a/packages/admin/src/utils/fetchDataOrGetRedirect.test.ts
+++ b/packages/admin/src/utils/fetchDataOrGetRedirect.test.ts
@@ -8,8 +8,8 @@ describe('fetchDataOrGetRedirect()', () => {
     const error = new AxiosError('Unauthorized');
     error.response = {
       ...error.response,
-      status: 401,
-      statusText: 'Unauthorized',
+      status: 403,
+      statusText: 'Forbidden',
     } as AxiosResponse;
     throw error;
   };

--- a/packages/admin/src/utils/fetchDataOrGetRedirect.ts
+++ b/packages/admin/src/utils/fetchDataOrGetRedirect.ts
@@ -14,9 +14,8 @@ async function fetchDataOrGetRedirect<T>(
 
 const getRedirect = (error: unknown) => {
   if (error instanceof AxiosError) {
-    const unauthorized =
-      error?.response?.status === 401 || error?.response?.status === 403;
-    if (unauthorized) {
+    const forbidden = error?.response?.status === 403;
+    if (forbidden) {
       return {
         redirect: {
           destination: '/404',
@@ -33,4 +32,4 @@ const getRedirect = (error: unknown) => {
   };
 };
 
-export { fetchDataOrGetRedirect };
+export { fetchDataOrGetRedirect, getRedirect };

--- a/packages/gap-web-ui/src/components/question-page/CallServiceMethod.tsx
+++ b/packages/gap-web-ui/src/components/question-page/CallServiceMethod.tsx
@@ -32,7 +32,8 @@ export default async function CallServiceMethod<B extends PageBodyResponse, R>(
   res: GetServerSidePropsContext['res'],
   serviceFunc: (body: B) => Promise<R>,
   redirectTo: string | ((result: R) => string),
-  errorPageParams: ServiceError | string
+  errorPageParams: ServiceError | string,
+  handleRequestError?: (err: unknown) => NextRedirect
 ): Promise<
   { body: B; fieldErrors: ValidationError[] } | { redirect: Redirect } | void
 > {
@@ -51,6 +52,9 @@ export default async function CallServiceMethod<B extends PageBodyResponse, R>(
       typeof redirectTo === 'string' ? redirectTo : redirectTo(result)
     );
   } catch (err: any) {
+    if (handleRequestError) {
+      return handleRequestError(err);
+    }
     const validationErrors = getValidationErrors(err, body);
     if (validationErrors) return validationErrors;
     if (err.code) return generateErrorPageRedirect(err, errorPageParams);

--- a/packages/gap-web-ui/src/components/question-page/QuestionPageGetServerSidePropsTypes.ts
+++ b/packages/gap-web-ui/src/components/question-page/QuestionPageGetServerSidePropsTypes.ts
@@ -9,6 +9,7 @@ type PageBodyResponse = Record<string, string | string[]>;
 type FetchPageData = Record<string, any>;
 
 type QuestionPageGetServerSidePropsType<T, K, V> = {
+  fetchPageDataErrorHandler?: (err: unknown) => NextRedirect;
   context: GetServerSidePropsContext;
   fetchPageData: (jwt: string) => Promise<K>;
   handleRequest: (body: T, jwt: string) => Promise<V>;
@@ -16,6 +17,7 @@ type QuestionPageGetServerSidePropsType<T, K, V> = {
   onSuccessRedirectHref: string | ((result: V) => string);
   onErrorMessage: string;
   useHandleRequestForPageData?: boolean;
+  handleRequestError?: (err: unknown) => NextRedirect;
 };
 
 type PostPageResultProps<T extends PageBodyResponse, V> = {
@@ -27,6 +29,7 @@ type PostPageResultProps<T extends PageBodyResponse, V> = {
   onErrorMessage: string;
   resolvedUrl: string;
   useHandleRequestForPageData?: boolean;
+  fetchPageDataErrorHandler?: (err: unknown) => NextRedirect;
 };
 
 type generateValidationPropsType<T> = void | {

--- a/packages/gap-web-ui/src/components/question-page/QuestionPageGetServerSidePropsTypes.ts
+++ b/packages/gap-web-ui/src/components/question-page/QuestionPageGetServerSidePropsTypes.ts
@@ -17,7 +17,6 @@ type QuestionPageGetServerSidePropsType<T, K, V> = {
   onSuccessRedirectHref: string | ((result: V) => string);
   onErrorMessage: string;
   useHandleRequestForPageData?: boolean;
-  handleRequestError?: (err: unknown) => NextRedirect;
 };
 
 type PostPageResultProps<T extends PageBodyResponse, V> = {


### PR DESCRIPTION
- adds a new prop in QuestionPageGetServerSideProps for custom fetchPageData error handling
- fetchPageDataOrRedirect redirects to login screen when the user is not logged in
related pr: https://github.com/cabinetoffice/gap-find-admin-backend/pull/13