### PR TITLE
Gap 2131 fix manage departments

### DIFF
--- a/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.page.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.page.tsx
@@ -1,12 +1,7 @@
-import {
-  Button,
-  QuestionPageGetServerSideProps,
-  SummaryList,
-} from 'gap-web-ui';
+import { SummaryList } from 'gap-web-ui';
 import { getAllDepartments } from '../../../services/SuperAdminService';
 import { getUserTokenFromCookies } from '../../../utils/session';
 import InferProps from '../../../types/InferProps';
-import getConfig from 'next/config';
 import Meta from '../../../components/layout/Meta';
 import CustomLink from '../../../components/custom-link/CustomLink';
 import { GetServerSidePropsContext } from 'next';
@@ -31,6 +26,9 @@ const ManageDepartmentsPage = ({
   departments,
   userId,
 }: InferProps<typeof getServerSideProps>) => {
+  const rows = departments.map((dept) => getDepartmentRow(dept));
+  rows.splice(0, 0, getManageDepartmentsHeadingRow());
+
   return (
     <>
       <Meta title="Manage Departments" />
@@ -44,11 +42,7 @@ const ManageDepartmentsPage = ({
       />
       <div className="govuk-!-padding-top-7">
         <h1 className="govuk-heading-l">Manage departments</h1>
-        <SummaryList
-          boldHeaderRow
-          hasWiderKeyColumn
-          rows={departments.map((dept, idx) => getDepartmentRow(idx, dept))}
-        />
+        <SummaryList boldHeaderRow hasWiderKeyColumn rows={rows} />
         <CustomLink
           href={`/super-admin-dashboard/manage-departments/add`}
           isButton
@@ -61,28 +55,22 @@ const ManageDepartmentsPage = ({
   );
 };
 
-const getDepartmentRow = (
-  index: number,
-  { id, name, ggisID = '' }: Department
-): Row =>
-  index === 0
-    ? {
-        key: 'Department',
-        value: 'GGIS ID',
-        action: <span className={styles['float-left-sm']}>Actions</span>,
-      }
-    : {
-        key: name,
-        value: ggisID,
-        action: (
-          <div className={styles['float-left-sm']}>
-            <CustomLink
-              href={`/super-admin-dashboard/manage-departments/edit/${id}`}
-            >
-              Edit
-            </CustomLink>
-          </div>
-        ),
-      };
+const getManageDepartmentsHeadingRow = (): Row => ({
+  key: 'Department',
+  value: 'GGIS ID',
+  action: <span className={styles['float-left-sm']}>Actions</span>,
+});
+
+const getDepartmentRow = ({ id, name, ggisID = '' }: Department): Row => ({
+  key: name,
+  value: ggisID,
+  action: (
+    <div className={styles['float-left-sm']}>
+      <CustomLink href={`/super-admin-dashboard/manage-departments/edit/${id}`}>
+        Edit
+      </CustomLink>
+    </div>
+  ),
+});
 
 export default ManageDepartmentsPage;


### PR DESCRIPTION
Issue was that to render the column headings we were checking for the first index of the array, which was the Cabinet office department.

Fix was to remove that check instead adding the columns always to the first index of the department array 