### PR TITLE
Gap 2188 fix copy for document upload

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.page.tsx
@@ -257,7 +257,7 @@ const QuestionType = ({
                 value: ResponseType.SingleFileUpload,
                 hint: (
                   <QuestionTypeHint
-                    description="Allows all documents except .xls and .exe to be uploaded."
+                    description="Allows files that are .DOC, .DOCX, .ODT, .PDF, .XLS, .XLSX or .ZIP"
                     questionType="document-upload"
                     imageFileName="document-upload"
                     imageAlt="A screenshot of a document upload component, with a button that allows the user to choose a file to upload"

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.test.tsx
@@ -125,7 +125,7 @@ describe('Question type', () => {
       render(component);
       screen.getByRole('radio', { name: 'Document upload' });
       screen.getByText(
-        'Allows all documents except .xls and .exe to be uploaded.'
+        'Allows files that are .DOC, .DOCX, .ODT, .PDF, .XLS, .XLSX or .ZIP'
       );
     });
 

--- a/packages/gap-web-ui/src/components/question-page/inputs/DocumentUpload.test.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/DocumentUpload.test.tsx
@@ -56,7 +56,9 @@ describe('Document Upload component', () => {
 
   it('Should render a label with the relevant accepted doc types', () => {
     render(<DocumentUpload {...props()} />);
-    screen.getByText('Upload a file (all documents except .xls and .exe)');
+    screen.getByText(
+      'Upload a file (Allows files that are .DOC, .DOCX, .ODT, .PDF, .XLS, .XLSX or .ZIP)'
+    );
   });
 
   it('Should NOT render an error message when there are no field errors', () => {

--- a/packages/gap-web-ui/src/components/question-page/inputs/DocumentUpload.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/DocumentUpload.tsx
@@ -42,7 +42,8 @@ const DocumentUpload = ({
       )}
 
       <label className="govuk-label govuk-!-margin-top-8" htmlFor={fieldName}>
-        Upload a file (all documents except .xls and .exe)
+        Upload a file (Allows files that are .DOC, .DOCX, .ODT, .PDF, .XLS,
+        .XLSX or .ZIP)
       </label>
 
       <ErrorMessage fieldErrors={fieldErrors} fieldName={fieldName} />


### PR DESCRIPTION
## Description

GAP-2188 (https://technologyprogramme.atlassian.net/browse/GAP-2188)

Summary of the changes and the related issue. List any dependencies that are required for this change:

Guidance was inconsistent between applicant and admin view for document upload selection. Content for grant admins was changed to  be - "Allows files that are .DOC, .DOCX, .ODT, .PDF, .XLS, .XLSX or .ZIP"

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Document Upload selection
<img width="649" alt="Screenshot 2023-09-26 at 16 31 14" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/145372589/57b1df5f-da63-4d04-92c7-34179fd3ca8b">

Document Upload preview
<img width="633" alt="Screenshot 2023-09-27 at 16 50 59" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/145372589/91ef2edf-354f-4f53-ae07-560c53068560">


Please attach screenshots of the change if it is a UI change:
Screenshot attached which shows the new text added for document upload description when being viewed by admins.

# Checklist:

- [ ] If I have listed depedenencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
