### PR TITLE
Redirect to grant-is-closed when application is REMOVED

### DIFF
--- a/packages/applicant/src/pages/submissions/[submissionId]/sections.page.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections.page.test.tsx
@@ -20,6 +20,10 @@ jest.mock('../../../utils/constants');
 jest.mock('../../../utils/jwt');
 jest.mock('../../../utils/csrf');
 
+jest.mock('../../../services/ApplicationService', () => ({
+  getApplicationStatusBySchemeId: jest.fn().mockResolvedValue('PUBLISHED'),
+}));
+
 jest.mock('next/config', () => () => {
   return {
     serverRuntimeConfig: {

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections.page.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections.page.test.tsx
@@ -14,6 +14,7 @@ import {
 import { createMockRouter } from '../../../testUtils/createMockRouter';
 import { getJwtFromCookies } from '../../../utils/jwt';
 import SubmissionSections, { getServerSideProps } from './sections.page';
+import { getApplicationStatusBySchemeId } from '../../../services/ApplicationService';
 
 jest.mock('../../../services/SubmissionService');
 jest.mock('../../../utils/constants');
@@ -21,7 +22,7 @@ jest.mock('../../../utils/jwt');
 jest.mock('../../../utils/csrf');
 
 jest.mock('../../../services/ApplicationService', () => ({
-  getApplicationStatusBySchemeId: jest.fn().mockResolvedValue('PUBLISHED'),
+  getApplicationStatusBySchemeId: jest.fn(),
 }));
 
 jest.mock('next/config', () => () => {
@@ -238,7 +239,28 @@ const questionDataStandardEligibilityResponseNull = {
 };
 
 describe('getServerSideProps', () => {
+  it('should return a redirect to grant-is-closed when submission is REMOVED ', async () => {
+    (getApplicationStatusBySchemeId as jest.Mock).mockResolvedValue('REMOVED');
+    (getSubmissionById as jest.Mock).mockReturnValue(propsWithAllValues);
+    (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (hasSubmissionBeenSubmitted as jest.Mock).mockReturnValue(false);
+    (isSubmissionReady as jest.Mock).mockReturnValue(true);
+    (getQuestionById as jest.Mock).mockReturnValue(
+      questionDataStandardEligibilityResponseNo
+    );
+    const response = await getServerSideProps(context);
+    expect(response).toEqual({
+      redirect: {
+        destination: '/grant-is-closed',
+        permanent: false,
+      },
+    });
+  });
+
   it('should return sections, submissionId, applicationName', async () => {
+    (getApplicationStatusBySchemeId as jest.Mock).mockResolvedValue(
+      'PUBLISHED'
+    );
     (getSubmissionById as jest.Mock).mockReturnValue(propsWithAllValues);
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
     (hasSubmissionBeenSubmitted as jest.Mock).mockReturnValue(false);

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections.page.tsx
@@ -16,6 +16,7 @@ import { getJwtFromCookies } from '../../../utils/jwt';
 import { routes } from '../../../utils/routes';
 import { SUBMISSION_STATUS_TAGS } from '../../../utils/sectionStatusTags';
 import styles from './sections.module.scss';
+import { getApplicationStatusBySchemeId } from '../../../services/ApplicationService';
 
 const { publicRuntimeConfig } = getConfig();
 
@@ -36,6 +37,20 @@ export const getServerSideProps: GetServerSideProps<
 
   const { sections, grantSubmissionId, applicationName, grantSchemeId } =
     await getSubmissionById(submissionId, getJwtFromCookies(req));
+
+  const grantApplicationStatus = await getApplicationStatusBySchemeId(
+    grantSchemeId,
+    getJwtFromCookies(req)
+  );
+
+  if (grantApplicationStatus === 'REMOVED') {
+    return {
+      redirect: {
+        destination: `/grant-is-closed`,
+        permanent: false,
+      },
+    };
+  }
 
   const submissionReady = await isSubmissionReady(
     submissionId,

--- a/packages/applicant/src/services/ApplicationService.tsx
+++ b/packages/applicant/src/services/ApplicationService.tsx
@@ -15,6 +15,17 @@ export async function getApplicationsListById(
   return data;
 }
 
+export const getApplicationStatusBySchemeId = async (
+  schemeId: string,
+  jwt: string
+) => {
+  const { data } = await axios.get<string>(
+    `${BACKEND_HOST}/grant-application/${schemeId}/status`,
+    axiosConfig(jwt)
+  );
+  return data;
+};
+
 export interface ApplicationsList {
   grantSchemeId: string;
   grantApplicationId: string;


### PR DESCRIPTION
## Description

Ticket # and link - https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2218

Consumes new applicant endpoint and redirects to grant-is-closed when the application has been closed

related prs:
https://github.com/cabinetoffice/gap-find-applicant-backend/pull/22
https://github.com/cabinetoffice/gap-find-lambda-scheduled-publishing/pull/4
https://github.com/cabinetoffice/gap-find-admin-backend/pull/42

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed depedenencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
