### PR TITLE
Adds redirect url to user-service call if navigating directly to mandatory questions start page

### DIFF
--- a/packages/applicant/src/middleware.page.ts
+++ b/packages/applicant/src/middleware.page.ts
@@ -3,12 +3,10 @@ import cookieParser from 'cookie-parser';
 // eslint-disable-next-line @next/next/no-server-import-in-page
 import { NextRequest, NextResponse, URLPattern } from 'next/server';
 import { verifyToken } from './services/JwtService';
-import { getLoginUrl } from './utils/general';
 
 const USER_TOKEN_NAME = process.env.USER_TOKEN_NAME;
 const HOST = process.env.HOST;
 const ONE_LOGIN_ENABLED = process.env.ONE_LOGIN_ENABLED === 'true';
-const LOGIN_URL = getLoginUrl();
 
 // //it will apply the middleware to all those paths
 export const config = {
@@ -35,6 +33,15 @@ function isWithinNumberOfMinsOfExpiry(expiresAt: Date, numberOfMins: number) {
 
 export function buildMiddlewareResponse(req: NextRequest, redirectUri: string) {
   const res = NextResponse.redirect(redirectUri);
+  if (mandatoryQuestionsStartPattern.test({ pathname: req.nextUrl.pathname })) {
+    const url =
+      redirectUri +
+      '?redirectUrl=' +
+      process.env.HOST +
+      req.nextUrl.pathname +
+      req.nextUrl.search;
+    return NextResponse.redirect(url);
+  }
   if (newApplicationPattern.test({ pathname: req.nextUrl.pathname })) {
     res.cookies.set(
       process.env.APPLYING_FOR_REDIRECT_COOKIE,
@@ -136,4 +143,8 @@ const redirectFromFindPattern = new URLPattern({
 
 const signInDetailsPage = new URLPattern({
   pathname: '/sign-in-details',
+});
+
+const mandatoryQuestionsStartPattern = new URLPattern({
+  pathname: '/mandatory-questions/start',
 });

--- a/packages/applicant/src/pages/index.page.test.tsx
+++ b/packages/applicant/src/pages/index.page.test.tsx
@@ -4,6 +4,7 @@ import { RouterContext } from 'next/dist/shared/lib/router-context';
 import { createMockRouter } from '../testUtils/createMockRouter';
 import Home, { getServerSideProps } from './index.page';
 import { getLoginUrl } from '../utils/general';
+import { merge } from 'lodash';
 
 describe('getServerSideProps', () => {
   it('should return page props', async () => {
@@ -11,6 +12,48 @@ describe('getServerSideProps', () => {
     expect(response).toEqual({
       props: {
         loginUrl: getLoginUrl(),
+        oneLoginEnabled: process.env.ONE_LOGIN_ENABLED,
+        registerUrl: `${process.env.USER_SERVICE_URL}/register`,
+      },
+    });
+  });
+  it('should overwrite loginUrl when redirecturl is provided', async () => {
+    const redirectUrl = 'http://localhost:3001/mandtory-questions/start';
+    process.env.LOGIN_URL = 'http://baseLoginUrl?redirectUrl=' + redirectUrl;
+    process.env.V2_LOGIN_URL = 'http://baseLoginUrl?redirectUrl=' + redirectUrl;
+
+    const props = {
+      req: {
+        query: {
+          redirectUrl: redirectUrl,
+        },
+      },
+    };
+    const response = await getServerSideProps(merge(props));
+    expect(response).toEqual({
+      props: {
+        loginUrl: `http://baseLoginUrl?redirectUrl=${redirectUrl}`,
+        oneLoginEnabled: process.env.ONE_LOGIN_ENABLED,
+        registerUrl: `${process.env.USER_SERVICE_URL}/register`,
+      },
+    });
+  });
+  it('should not override loginUrl when redirecturl is undefined', async () => {
+    process.env.LOGIN_URL = 'http://baseLoginUrl';
+    process.env.V2_LOGIN_URL = 'http://baseLoginUrl';
+
+    const props = {
+      req: {
+        query: {
+          redirectUrl: undefined,
+        },
+      },
+    };
+
+    const response = await getServerSideProps(merge(props));
+    expect(response).toEqual({
+      props: {
+        loginUrl: `http://baseLoginUrl`,
         oneLoginEnabled: process.env.ONE_LOGIN_ENABLED,
         registerUrl: `${process.env.USER_SERVICE_URL}/register`,
       },

--- a/packages/applicant/src/pages/index.page.tsx
+++ b/packages/applicant/src/pages/index.page.tsx
@@ -5,10 +5,19 @@ import Meta from '../components/partials/Meta';
 import { getLoginUrl } from '../utils/general';
 import getConfig from 'next/config';
 
-export const getServerSideProps: GetServerSideProps = () => {
+export const getServerSideProps: GetServerSideProps = (req) => {
+  let loginUrl = getLoginUrl();
+
+  // overwrite default redirectUrl if one is provided
+  if (req?.query?.redirectUrl) {
+    loginUrl = loginUrl.replace(
+      /(\?|&)redirectUrl=([^&]*)/,
+      '$1redirectUrl=' + req.query.redirectUrl
+    );
+  }
   return Promise.resolve({
     props: {
-      loginUrl: getLoginUrl(),
+      loginUrl: loginUrl,
       registerUrl: `${process.env.USER_SERVICE_URL}/register`,
       oneLoginEnabled: process.env.ONE_LOGIN_ENABLED,
     },


### PR DESCRIPTION
## Description
Currently the redirect url is defaulted and set in the env var (V2_LOGIN_URL)

This change adds redirect url to user-service call if navigating directly to mandatory questions start page

- Updates index page to override login redirect url if one is passed in, this is then sent to user-service
- Added check in the middleware to set redirectUrl to the mandatory question start page
- Added unit tests to cover redirectUrl existing and being undefined

Ticket # and link

https://technologyprogramme.atlassian.net/browse/TMI2-440

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed depedenencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
