### PR TITLE
Fix trigger CD on push & create

### DIFF
--- a/.github/workflows/admin-ci.yml
+++ b/.github/workflows/admin-ci.yml
@@ -15,8 +15,6 @@ jobs:
   install:
     name: Install dependencies
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     outputs: 
       gap-web-ui-hash: ${{ steps.gap-web-ui-hash.outputs.name }}
@@ -74,8 +72,6 @@ jobs:
     name: Build app
     needs: install
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/admin-sandbox-qa-cd.yml
+++ b/.github/workflows/admin-sandbox-qa-cd.yml
@@ -1,10 +1,11 @@
 name: Admin CD
 
 on:
-  pull_request:
+  create:
+  push:
     branches:
       - release/**
-      - main
+      - develop
     paths:
       - "packages/admin/**"
       - "packages/gap-web-ui/**"
@@ -14,6 +15,9 @@ on:
 
 jobs:
   test:
+      # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
+      if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+
       name: Test app
 
       runs-on: ubuntu-latest
@@ -97,6 +101,9 @@ jobs:
           run: yarn jest --selectProjects gap-web-ui --runInBand --ci
           
   build:
+    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+      
     runs-on: ubuntu-latest
 
     outputs:
@@ -149,6 +156,9 @@ jobs:
           retention-days: 1
   
   deploy:
+    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+  
     needs: [build, test]
 
     environment: AWS

--- a/.github/workflows/admin-sandbox-qa-cd.yml
+++ b/.github/workflows/admin-sandbox-qa-cd.yml
@@ -156,9 +156,6 @@ jobs:
           retention-days: 1
   
   deploy:
-    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
-    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
-  
     needs: [build, test]
 
     environment: AWS

--- a/.github/workflows/admin-sandbox-qa-cd.yml
+++ b/.github/workflows/admin-sandbox-qa-cd.yml
@@ -1,10 +1,10 @@
 name: Admin CD
 
 on:
-  push:
+  pull_request:
     branches:
       - release/**
-      - develop
+      - main
     paths:
       - "packages/admin/**"
       - "packages/gap-web-ui/**"

--- a/.github/workflows/admin-sandbox-qa-cd.yml
+++ b/.github/workflows/admin-sandbox-qa-cd.yml
@@ -18,9 +18,6 @@ jobs:
 
       runs-on: ubuntu-latest
 
-      permissions:
-        contents: read
-
       steps:
         - name: Checkout repo
           uses: actions/checkout@v4

--- a/.github/workflows/applicant-ci.yml
+++ b/.github/workflows/applicant-ci.yml
@@ -15,8 +15,6 @@ jobs:
   install:
     name: Install dependencies
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     outputs: 
       gap-web-ui-hash: ${{ steps.gap-web-ui-hash.outputs.name }}
@@ -74,8 +72,6 @@ jobs:
     name: Build app
     needs: install
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/applicant-sandbox-qa-cd.yml
+++ b/.github/workflows/applicant-sandbox-qa-cd.yml
@@ -1,13 +1,13 @@
 name: Applicant CD
 
 on:
-  push:
+  pull_request:
     branches:
       - release/**
-      - develop
+      - main
     paths:
       - "packages/applicant/**"
-      - "packages/gap-web-ui/**"
+      - "packages/gap-web-ui/**"  
       - ".github/workflows/applicant-sandbox-qa-cd.yml"
       - "package.json"
       - "yarn.lock"

--- a/.github/workflows/applicant-sandbox-qa-cd.yml
+++ b/.github/workflows/applicant-sandbox-qa-cd.yml
@@ -7,7 +7,7 @@ on:
       - main
     paths:
       - "packages/applicant/**"
-      - "packages/gap-web-ui/**"  
+      - "packages/gap-web-ui/**"
       - ".github/workflows/applicant-sandbox-qa-cd.yml"
       - "package.json"
       - "yarn.lock"

--- a/.github/workflows/applicant-sandbox-qa-cd.yml
+++ b/.github/workflows/applicant-sandbox-qa-cd.yml
@@ -1,10 +1,11 @@
 name: Applicant CD
 
 on:
-  pull_request:
+  create:
+  push:
     branches:
       - release/**
-      - main
+      - develop
     paths:
       - "packages/applicant/**"
       - "packages/gap-web-ui/**"
@@ -14,6 +15,9 @@ on:
 
 jobs:
   test:
+      # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
+      if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+      
       name: Test app
 
       runs-on: ubuntu-latest
@@ -97,6 +101,9 @@ jobs:
           run: yarn jest --selectProjects gap-web-ui --runInBand --ci
 
   build:
+    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+      
     runs-on: ubuntu-latest
 
     outputs:
@@ -149,6 +156,9 @@ jobs:
           retention-days: 1
 
   deploy:
+    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+      
     needs: [build, test]
 
     environment: AWS

--- a/.github/workflows/applicant-sandbox-qa-cd.yml
+++ b/.github/workflows/applicant-sandbox-qa-cd.yml
@@ -156,9 +156,6 @@ jobs:
           retention-days: 1
 
   deploy:
-    # Need to check here as create event can't be filtered by branch name: https://github.com/orgs/community/discussions/54860
-    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
-      
     needs: [build, test]
 
     environment: AWS

--- a/.github/workflows/applicant-sandbox-qa-cd.yml
+++ b/.github/workflows/applicant-sandbox-qa-cd.yml
@@ -18,9 +18,6 @@ jobs:
 
       runs-on: ubuntu-latest
 
-      permissions:
-        contents: read
-
       steps:
         - name: Checkout repo
           uses: actions/checkout@v4

--- a/.github/workflows/gap-web-ui-ci.yml
+++ b/.github/workflows/gap-web-ui-ci.yml
@@ -16,9 +16,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Now triggers on creation & pushes to develop or release branches
- Removing unnecessary contents read permissions
- Annoyingly create cant specify branches, so an additional check is needed per job as per: https://github.com/orgs/community/discussions/26286#discussioncomment-3251208