### PR TITLE
GAP-2247 Add conditional logic to name and address

### DIFF
--- a/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-address.page.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-address.page.tsx
@@ -5,6 +5,7 @@ import Meta from '../../../components/partials/Meta';
 import InferProps from '../../../types/InferProps';
 import { routes } from '../../../utils/routes';
 import getServerSideProps from './getServerSideProps';
+import { MQ_ORG_TYPES } from '../../../utils/constants';
 
 export { getServerSideProps };
 
@@ -14,7 +15,10 @@ export default function MandatoryQuestionOrganisationAddressPage({
   formAction,
   defaultFields,
   backButtonUrl,
+  mandatoryQuestion,
 }: InferProps<typeof getServerSideProps>) {
+  const isUserIndividual =
+    mandatoryQuestion.orgType === MQ_ORG_TYPES.INDIVIDUAL;
   const commonAddressInputProps = {
     boldHeading: false,
     titleSize: 's',
@@ -39,7 +43,9 @@ export default function MandatoryQuestionOrganisationAddressPage({
             className="govuk-heading-l"
             data-cy="cy-addressInput-question-title"
           >
-            Enter your organisation&apos;s address
+            {isUserIndividual
+              ? 'Enter your address'
+              : "Enter your organisation's address"}
           </h1>
 
           <TextInput

--- a/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-address.test.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-address.test.tsx
@@ -7,12 +7,14 @@ import InferProps from '../../../types/InferProps';
 import MandatoryQuestionOrganisationAddressPage, {
   getServerSideProps,
 } from './organisation-address.page';
+import { MQ_ORG_TYPES } from '../../../utils/constants';
 
 describe('Organisation address page', () => {
   const getDefaultProps = (): InferProps<typeof getServerSideProps> => ({
     fieldErrors: [],
     csrfToken: 'testCSRFToken',
     formAction: 'testFormAction',
+    backButtonUrl: 'testBackButtonUrl',
     defaultFields: {
       addressLine1: '',
       addressLine2: '',
@@ -22,17 +24,35 @@ describe('Organisation address page', () => {
     },
     mandatoryQuestion: {
       schemeId: 1,
+      orgType: MQ_ORG_TYPES.INDIVIDUAL,
     },
     mandatoryQuestionId: 'mandatoryQuestionId',
   });
 
-  it('should display a heading', () => {
+  it('should display a heading for individuals', () => {
     renderWithRouter(
       <MandatoryQuestionOrganisationAddressPage
         {...getPageProps(getDefaultProps)}
       />
     );
 
+    screen.getByRole('heading', {
+      name: 'Enter your address',
+      level: 1,
+    });
+  });
+
+  it('should display a heading for organisations', () => {
+    renderWithRouter(
+      <MandatoryQuestionOrganisationAddressPage
+        {...getPageProps(getDefaultProps, {
+          mandatoryQuestion: {
+            schemeId: 1,
+            orgType: MQ_ORG_TYPES.LIMITED_COMPANY,
+          },
+        })}
+      />
+    );
     screen.getByRole('heading', {
       name: "Enter your organisation's address",
       level: 1,

--- a/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-name.page.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-name.page.tsx
@@ -7,8 +7,8 @@ import {
 import Layout from '../../../components/partials/Layout';
 import Meta from '../../../components/partials/Meta';
 import InferProps from '../../../types/InferProps';
-import { routes } from '../../../utils/routes';
 import getServerSideProps from './getServerSideProps';
+import { MQ_ORG_TYPES } from '../../../utils/constants';
 
 export { getServerSideProps };
 export default function MandatoryQuestionOrganisationNamePage({
@@ -17,38 +17,47 @@ export default function MandatoryQuestionOrganisationNamePage({
   formAction,
   defaultFields,
   backButtonUrl,
+  mandatoryQuestion,
 }: InferProps<typeof getServerSideProps>) {
+  const isUserIndividual =
+    mandatoryQuestion.orgType === MQ_ORG_TYPES.INDIVIDUAL;
   return (
     <>
-      <>
-        <Meta
-          title={`${
-            fieldErrors.length > 0 ? 'Error: ' : ''
-          }Organisation name - Apply for a grant`}
-        />
+      <Meta
+        title={`${
+          fieldErrors.length > 0 ? 'Error: ' : ''
+        }Organisation name - Apply for a grant`}
+      />
 
-        <Layout backBtnUrl={backButtonUrl}>
-          <FlexibleQuestionPageLayout
-            formAction={formAction}
+      <Layout backBtnUrl={backButtonUrl}>
+        <FlexibleQuestionPageLayout
+          formAction={formAction}
+          fieldErrors={fieldErrors}
+          csrfToken={csrfToken}
+        >
+          <TextInput
+            questionTitle={
+              isUserIndividual
+                ? 'Enter your name'
+                : 'Enter the name of your organisation'
+            }
+            questionHintText={
+              isUserIndividual
+                ? 'Your name will appear on your application.'
+                : 'This is the official name of your organisation. It could be the name that is registered with Companies House or the Charities Commission'
+            }
+            fieldName="name"
+            defaultValue={defaultFields.name}
             fieldErrors={fieldErrors}
-            csrfToken={csrfToken}
-          >
-            <TextInput
-              questionTitle="Enter the name of your organisation"
-              questionHintText="This is the official name of your organisation. It could be the name that is registered with Companies House or the Charities Commission"
-              fieldName="name"
-              defaultValue={defaultFields.name}
-              fieldErrors={fieldErrors}
-              width="30"
-            />
+            width="30"
+          />
 
-            <Button
-              text="Save and continue"
-              type={ButtonTypePropertyEnum.Submit}
-            />
-          </FlexibleQuestionPageLayout>
-        </Layout>
-      </>
+          <Button
+            text="Save and continue"
+            type={ButtonTypePropertyEnum.Submit}
+          />
+        </FlexibleQuestionPageLayout>
+      </Layout>
     </>
   );
 }

--- a/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-name.test.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-name.test.tsx
@@ -7,12 +7,14 @@ import InferProps from '../../../types/InferProps';
 import MandatoryQuestionOrganisationNamePage, {
   getServerSideProps,
 } from './organisation-name.page';
+import { MQ_ORG_TYPES } from '../../../utils/constants';
 
 describe('Organisation name page', () => {
   const getDefaultProps = (): InferProps<typeof getServerSideProps> => ({
     fieldErrors: [],
     csrfToken: 'testCSRFToken',
     formAction: 'testFormAction',
+    backButtonUrl: 'testBackButtonUrl',
     defaultFields: {
       name: '',
     },
@@ -41,10 +43,39 @@ describe('Organisation name page', () => {
         {...getPageProps(getDefaultProps)}
       />
     );
+  });
 
-    screen.getByText(
-      'This is the official name of your organisation. It could be the name that is registered with Companies House or the Charities Commission'
+  it('should display a different heading if user is individual', () => {
+    renderWithRouter(
+      <MandatoryQuestionOrganisationNamePage
+        {...getPageProps(getDefaultProps, {
+          mandatoryQuestion: {
+            schemeId: 1,
+            orgType: MQ_ORG_TYPES.INDIVIDUAL,
+          },
+        })}
+      />
     );
+
+    screen.getByRole('heading', {
+      name: 'Enter your name',
+      level: 1,
+    });
+  });
+
+  it('should display a different question hint text if user is individual', () => {
+    renderWithRouter(
+      <MandatoryQuestionOrganisationNamePage
+        {...getPageProps(getDefaultProps, {
+          mandatoryQuestion: {
+            schemeId: 1,
+            orgType: MQ_ORG_TYPES.INDIVIDUAL,
+          },
+        })}
+      />
+    );
+
+    screen.getByText('Your name will appear on your application.');
   });
 
   it('should display text input with no default', () => {


### PR DESCRIPTION
## Description

Adds conditional logic to name and address

Ticket # and link

[GAP-2247](https://technologyprogramme.atlassian.net/browse/GAP-2247?atlOrigin=eyJpIjoiOTEwYzI1MzYxNWYxNDU1Nzg5NmEyOGMwOGM1ZGJjMDYiLCJwIjoiaiJ9)

Summary of the changes and the related issue. List any dependencies that are required for this change:

Adds ternary logic for name and address content displays

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependenencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2247]: https://technologyprogramme.atlassian.net/browse/GAP-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ