### PR TITLE
Sanitises filename to prevent Content Disposition error

### DIFF
--- a/packages/admin/src/utils/QuestionPageGetServerSideProps.tsx
+++ b/packages/admin/src/utils/QuestionPageGetServerSideProps.tsx
@@ -1,4 +1,3 @@
-import { resolve } from 'styled-jsx/css';
 import CallServiceMethod from './callServiceMethod';
 import {
   ValidationError,
@@ -76,8 +75,6 @@ async function fetchAndHandlePageData<K extends FetchPageData>(
     return await fetchPageData(jwt);
   } catch (err: any) {
     if (err?.response?.data?.code) {
-      console.log('hello');
-      console.log(resolvedUrl);
       return generateRedirect(
         `/error-page/code/${err.response.data.code}?href=${resolvedUrl}`
       );

--- a/packages/applicant/src/pages/api/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.page.tsx
+++ b/packages/applicant/src/pages/api/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.page.tsx
@@ -87,6 +87,11 @@ const handler = async (req, res) => {
     const questionId = req.query.questionId.toString();
     const jwt = getJwtFromCookies(req);
     const formData = await getfileFromRequest(req);
+
+    formData.files.attachment.originalFilename = santizeFileName(
+      formData.files.attachment.originalFilename
+    );
+
     const questionData = await getQuestionById(
       submissionId,
       sectionId,
@@ -185,6 +190,11 @@ const handler = async (req, res) => {
   } else {
     res.status(405).json({ error: `Method '${req.method}' Not Allowed` });
   }
+};
+
+const santizeFileName = (fileName: string) => {
+  const regex = /[^a-zA-Z0-9()_,.-]/g;
+  return fileName.replace(regex, '_');
 };
 
 export default handler;


### PR DESCRIPTION
## Description

Sanitizes filename to safely remove characters that may be a threat or cause content disposition errors.

This is now consistent with the backend.

Tested with `testing ,.'";}{()%^*+£$!|.xlsx` and it will convert to `testing_,._____()________.xlsx`

Ticket # and link

https://technologyprogramme.atlassian.net/browse/GAP-2233

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed depedenencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
