### PR TITLE
TMI2-422: updated service-error page hrefs

### DIFF
--- a/packages/admin/src/pages/api/downloadDueDiligenceChecks.page.ts
+++ b/packages/admin/src/pages/api/downloadDueDiligenceChecks.page.ts
@@ -14,7 +14,7 @@ const downloadDueDiligenceChecks = async (
           errorInformation:
             'Something went wrong while trying to download due diligence information.',
           linkAttributes: {
-            href: req.headers.referer,
+            href: `/scheme/${schemeId}/manage-due-diligence-checks`,
             linkText: 'Please return',
             linkInformation: ' and try again.',
           },

--- a/packages/admin/src/pages/api/downloadRequiredChecks.page.ts
+++ b/packages/admin/src/pages/api/downloadRequiredChecks.page.ts
@@ -7,6 +7,7 @@ const downloadRequiredChecks = async (
   res: NextApiResponse
 ) => {
   const applicationId = req.query.applicationId as string;
+  const schemeId = req.query.schemeId as string;
   const errorRedirect = () => {
     res.redirect(
       `${process.env.SUB_PATH}/service-error?serviceErrorProps=${JSON.stringify(
@@ -14,7 +15,7 @@ const downloadRequiredChecks = async (
           errorInformation:
             'Something went wrong while trying to download required checks.',
           linkAttributes: {
-            href: req.headers.referer,
+            href: `/scheme/${schemeId}`,
             linkText: 'Please return',
             linkInformation: ' and try again.',
           },

--- a/packages/admin/src/pages/api/downloadRequiredChecks.test.ts
+++ b/packages/admin/src/pages/api/downloadRequiredChecks.test.ts
@@ -1,6 +1,6 @@
+import { merge } from 'lodash';
 import { spotlightExport } from '../../services/SubmissionsService';
 import downloadRequiredChecks from './downloadRequiredChecks.page';
-import { merge } from 'lodash';
 
 jest.mock('../../services/SubmissionsService');
 
@@ -16,6 +16,7 @@ const req = (overrides: any = {}) =>
     {
       query: {
         applicationId: APPLICATION_ID,
+        schemeId: SCHEME_ID,
       },
       headers: {
         referer: `/scheme/${SCHEME_ID}`,

--- a/packages/admin/src/pages/api/downloadSpotlightChecks.page.ts
+++ b/packages/admin/src/pages/api/downloadSpotlightChecks.page.ts
@@ -14,7 +14,7 @@ const downloadSpotlightChecks = async (
           errorInformation:
             'Something went wrong while trying to download the information for Spotlight checks.',
           linkAttributes: {
-            href: req.headers.referer,
+            href: `/scheme/${schemeId}/manage-due-diligence-checks`,
             linkText: 'Please return',
             linkInformation: ' and try again.',
           },

--- a/packages/admin/src/pages/api/downloadSpotlightChecks.test.ts
+++ b/packages/admin/src/pages/api/downloadSpotlightChecks.test.ts
@@ -17,7 +17,7 @@ const req = (overrides: any = {}) =>
         schemeId: SCHEME_ID,
       },
       headers: {
-        referer: `/scheme/${SCHEME_ID}/manage-spotlight-checks`,
+        referer: `/scheme/${SCHEME_ID}/manage-due-diligence-checks`,
       },
       cookies: { sessionCookieName: 'testSessionId' },
     },
@@ -47,7 +47,7 @@ describe('spotlightExportHandler', () => {
 
     expect(mockedRedirect).toHaveBeenNthCalledWith(
       1,
-      `/apply/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to download the information for Spotlight checks.","linkAttributes":{"href":"/scheme/testSchemeId/manage-spotlight-checks","linkText":"Please return","linkInformation":" and try again."}}`
+      `/apply/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to download the information for Spotlight checks.","linkAttributes":{"href":"/scheme/testSchemeId/manage-due-diligence-checks","linkText":"Please return","linkInformation":" and try again."}}`
     );
   });
 
@@ -57,7 +57,7 @@ describe('spotlightExportHandler', () => {
     await downloadSpotlightChecks(req(), res());
     expect(mockedRedirect).toHaveBeenNthCalledWith(
       1,
-      `/apply/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to download the information for Spotlight checks.","linkAttributes":{"href":"/scheme/testSchemeId/manage-spotlight-checks","linkText":"Please return","linkInformation":" and try again."}}`
+      `/apply/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to download the information for Spotlight checks.","linkAttributes":{"href":"/scheme/testSchemeId/manage-due-diligence-checks","linkText":"Please return","linkInformation":" and try again."}}`
     );
   });
 

--- a/packages/admin/src/pages/scheme/[schemeId]/manage-due-diligence-checks.test.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/manage-due-diligence-checks.test.tsx
@@ -248,6 +248,8 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
         <ManageDueDiligenceChecks
           scheme={scheme}
           hasInfoToDownload={true}
+          spotlightSubmissionCount={2}
+          spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
         />
@@ -266,6 +268,8 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
         <ManageDueDiligenceChecks
           scheme={scheme}
           hasInfoToDownload={true}
+          spotlightSubmissionCount={2}
+          spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
         />

--- a/packages/admin/src/pages/scheme/components/SchemeApplications.tsx
+++ b/packages/admin/src/pages/scheme/components/SchemeApplications.tsx
@@ -166,7 +166,7 @@ const SchemeApplications = ({
                   </CustomLink>
                 </p>
                 <CustomLink
-                  href={`/api/downloadRequiredChecks?applicationId=${applicationForm.grantApplicationId}`}
+                  href={`/api/downloadRequiredChecks?applicationId=${applicationForm.grantApplicationId}&schemeId=${applicationForm.grantSchemeId}`}
                   isSecondaryButton
                   disabled={applicationFormStats.submissionCount === 0}
                   dataCy="cy_Scheme-details-page-button-Download required checks"


### PR DESCRIPTION
## Description
The link on the 'Please return' text on the service error page was incorrect and this has been updated with the correct hrefs

Ticket # and link
TMI2-422 https://technologyprogramme.atlassian.net/browse/TMI2-422

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed depedenencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
