### PR TITLE
TMI2-422: doesn't show link if no spotlight data to download

### DIFF
--- a/packages/admin/src/pages/scheme/[schemeId]/manage-due-diligence-checks.page.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/manage-due-diligence-checks.page.tsx
@@ -2,7 +2,10 @@ import { GetServerSidePropsContext } from 'next';
 import CustomLink from '../../../components/custom-link/CustomLink';
 import InsetText from '../../../components/inset-text/InsetText';
 import Meta from '../../../components/layout/Meta';
-import { completedMandatoryQuestions } from '../../../services/MandatoryQuestionsService';
+import {
+  completedMandatoryQuestions,
+  hasSpotlightData,
+} from '../../../services/MandatoryQuestionsService';
 import {
   getGrantScheme,
   schemeApplicationIsInternal,
@@ -25,7 +28,11 @@ export const getServerSideProps = async ({
   const isInternal = await schemeApplicationIsInternal(schemeId, sessionCookie);
   const spotlightUrl = process.env.SPOTLIGHT_LOGIN_URL;
   const hasInfoToDownload = await completedMandatoryQuestions(
-    scheme.schemeId,
+    schemeId,
+    sessionCookie
+  );
+  const hasSpotlightDataToDownload = await hasSpotlightData(
+    schemeId,
     sessionCookie
   );
 
@@ -50,6 +57,7 @@ export const getServerSideProps = async ({
       spotlightLastUpdated,
       spotlightUrl,
       isInternal,
+      hasSpotlightDataToDownload,
     },
   };
 };
@@ -61,6 +69,7 @@ const ManageDueDiligenceChecks = ({
   spotlightLastUpdated,
   spotlightUrl,
   isInternal,
+  hasSpotlightDataToDownload,
 }: InferProps<typeof getServerSideProps>) => {
   return (
     <>
@@ -148,15 +157,17 @@ const ManageDueDiligenceChecks = ({
                   <a href={spotlightUrl} className="govuk-button">
                     Log in to Spotlight
                   </a>
-                  <p className="govuk-body">
-                    You can{' '}
-                    <CustomLink
-                      href={`/api/downloadSpotlightChecks?schemeId=${scheme.schemeId}`}
-                    >
-                      download the information you need to run checks
-                    </CustomLink>{' '}
-                    to upload it to Spotlight manually.
-                  </p>
+                  {hasSpotlightDataToDownload && (
+                    <p className="govuk-body">
+                      You can{' '}
+                      <CustomLink
+                        href={`/api/downloadSpotlightChecks?schemeId=${scheme.schemeId}`}
+                      >
+                        download the information you need to run checks
+                      </CustomLink>{' '}
+                      to upload it to Spotlight manually.
+                    </p>
+                  )}
                   <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible"></hr>
                 </div>
               )}

--- a/packages/admin/src/pages/scheme/[schemeId]/manage-due-diligence-checks.test.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/manage-due-diligence-checks.test.tsx
@@ -120,6 +120,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
       expect(screen.getByRole('link', { name: 'Back' })).toHaveAttribute(
@@ -137,6 +138,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
       screen.getByRole('heading', { name: 'Manage due diligence checks' });
@@ -151,6 +153,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={false}
+          hasSpotlightDataToDownload={true}
         />
       );
       screen.getByText(
@@ -170,6 +173,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
       screen.getByText(
@@ -192,6 +196,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
 
@@ -211,6 +216,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={''}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
       expect(screen.getByTestId('spotlight-count')).toHaveTextContent(
@@ -230,6 +236,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
       screen.getByText(
@@ -252,6 +259,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
 
@@ -272,6 +280,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
 
@@ -285,6 +294,24 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
       );
     });
 
+    it('Should not render the spotlight checks download link if there is nothing to download', () => {
+      render(
+        <ManageDueDiligenceChecks
+          scheme={scheme}
+          hasInfoToDownload={true}
+          spotlightSubmissionCount={2}
+          spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
+          spotlightUrl="url"
+          isInternal={true}
+          hasSpotlightDataToDownload={false}
+        />
+      );
+
+      expect(
+        screen.queryByText('download the information you need to run checks')
+      ).not.toBeInTheDocument();
+    });
+
     it('Should render the download link', () => {
       render(
         <ManageDueDiligenceChecks
@@ -294,6 +321,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
 
@@ -316,6 +344,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={false}
+          hasSpotlightDataToDownload={true}
         />
       );
 
@@ -331,6 +360,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
 
@@ -348,6 +378,7 @@ describe('scheme/[schemeId]/manage-due-diligence-checks', () => {
           spotlightLastUpdated={SPOTLIGHT_LAST_UPDATED}
           spotlightUrl="url"
           isInternal={true}
+          hasSpotlightDataToDownload={true}
         />
       );
 

--- a/packages/admin/src/services/MandatoryQuestionsService.test.ts
+++ b/packages/admin/src/services/MandatoryQuestionsService.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import {
   completedMandatoryQuestions,
   downloadDueDiligenceData,
+  hasSpotlightData,
   spotlightExport,
 } from './MandatoryQuestionsService';
 
@@ -75,6 +76,44 @@ describe('MandatoryQuestionsService', () => {
 
       expect(mockedAxios.get).toHaveBeenCalledWith(
         `${BASE_MANDATORY_QUESTIONS_URL}/scheme/testSchemeId/complete`,
+        {
+          headers: { Cookie: 'SESSION=testSessionCookie;' },
+          withCredentials: true,
+        }
+      );
+      expect(response).toBeFalsy();
+    });
+  });
+
+  describe('hasSpotlightData function', () => {
+    it('Should return true if a scheme has completed mandatory questions for spotlight', async () => {
+      mockedAxios.get.mockResolvedValue({ data: true });
+
+      const response = await hasSpotlightData(
+        'testSchemeId',
+        'testSessionCookie'
+      );
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${BASE_MANDATORY_QUESTIONS_URL}/scheme/testSchemeId/spotlight-complete`,
+        {
+          headers: { Cookie: 'SESSION=testSessionCookie;' },
+          withCredentials: true,
+        }
+      );
+      expect(response).toBeTruthy();
+    });
+
+    it('Should return false if a scheme has no completed mandatory questions for spotlight', async () => {
+      mockedAxios.get.mockResolvedValue({ data: false });
+
+      const response = await hasSpotlightData(
+        'testSchemeId',
+        'testSessionCookie'
+      );
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${BASE_MANDATORY_QUESTIONS_URL}/scheme/testSchemeId/spotlight-complete`,
         {
           headers: { Cookie: 'SESSION=testSessionCookie;' },
           withCredentials: true,

--- a/packages/admin/src/services/MandatoryQuestionsService.ts
+++ b/packages/admin/src/services/MandatoryQuestionsService.ts
@@ -46,9 +46,21 @@ const completedMandatoryQuestions = async (
   return response.data;
 };
 
+const hasSpotlightData = async (
+  schemeId: string,
+  sessionCookie: string
+): Promise<boolean> => {
+  const response = await axios.get(
+    `${BASE_MANDATORY_QUESTIONS_URL}/scheme/${schemeId}/spotlight-complete`,
+    axiosSessionConfig(sessionCookie)
+  );
+  return response.data;
+};
+
 export {
   completedMandatoryQuestions,
   downloadDueDiligenceData,
+  hasSpotlightData,
   // eslint-disable-next-line prettier/prettier
   spotlightExport
 };


### PR DESCRIPTION
## Description
A missed scenario in the ticket was to not show the spotlight download link if there are no completed mandatory questions of the specified org type

Ticket # and link
TMI2-422 - https://technologyprogramme.atlassian.net/browse/TMI2-422

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
