### PR TITLE
TMI2-499: Fixing layout of unpublish application page

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/unpublish-confirmation.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/unpublish-confirmation.page.tsx
@@ -1,5 +1,5 @@
 import { FlexibleQuestionPageLayout, Radio, ValidationError } from 'gap-web-ui';
-import { GetServerSideProps } from 'next';
+import { GetServerSidePropsContext } from 'next';
 import CustomLink from '../../../components/custom-link/CustomLink';
 import Meta from '../../../components/layout/Meta';
 import { updateApplicationFormStatus } from '../../../services/ApplicationService';
@@ -7,17 +7,18 @@ import callServiceMethod from '../../../utils/callServiceMethod';
 import { getSessionIdFromCookies } from '../../../utils/session';
 import { errorPageParams } from './publish-service-errors';
 import getConfig from 'next/config';
+import InferProps from '../../../types/InferProps';
 
 type RequestBody = {
   confirmation: string;
 };
 
-export const getServerSideProps: GetServerSideProps = async ({
+export const getServerSideProps = async ({
   params,
   resolvedUrl,
   req,
   res,
-}) => {
+}: GetServerSidePropsContext) => {
   const { applicationId } = params as Record<string, string>;
 
   let fieldErrors = [] as ValidationError[];
@@ -81,7 +82,7 @@ const UnpublishConfirmationPage = ({
   formAction,
   fieldErrors,
   csrfToken,
-}: PublishConfirmationPageProps) => {
+}: InferProps<typeof getServerSideProps>) => {
   const { publicRuntimeConfig } = getConfig();
   return (
     <>
@@ -94,55 +95,43 @@ const UnpublishConfirmationPage = ({
       <CustomLink isBackButton href={backHref} />
 
       <div className="govuk-!-padding-top-7">
-        <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">
-            <FlexibleQuestionPageLayout
-              formAction={formAction}
-              fieldErrors={fieldErrors}
-              csrfToken={csrfToken}
-            >
-              <Radio
-                questionTitle="Are you sure you want to unpublish this application form?"
-                questionHintText={
-                  <p className="govuk-body">
-                    Once unpublished, your application form will no longer
-                    appear on{' '}
-                    <a
-                      href={publicRuntimeConfig.FIND_A_GRANT_URL}
-                      className="govuk-link"
-                    >
-                      Find a grant
-                    </a>{' '}
-                    and applications cannot be submitted.
-                  </p>
-                }
-                fieldName="confirmation"
-                fieldErrors={fieldErrors}
-              />
-              <div className="govuk-button-group">
-                <button
-                  className="govuk-button"
-                  data-module="govuk-button"
-                  data-cy="cy_unpublishConfirmation-ConfirmButton"
+        <FlexibleQuestionPageLayout
+          formAction={formAction}
+          fieldErrors={fieldErrors}
+          csrfToken={csrfToken}
+        >
+          <Radio
+            questionTitle="Are you sure you want to unpublish this application form?"
+            questionHintText={
+              <p className="govuk-body">
+                Once unpublished, your application form will no longer appear on{' '}
+                <a
+                  href={publicRuntimeConfig.FIND_A_GRANT_URL}
+                  className="govuk-link"
                 >
-                  Confirm
-                </button>
+                  Find a grant
+                </a>{' '}
+                and applications cannot be submitted.
+              </p>
+            }
+            fieldName="confirmation"
+            fieldErrors={fieldErrors}
+          />
+          <div className="govuk-button-group">
+            <button
+              className="govuk-button"
+              data-module="govuk-button"
+              data-cy="cy_unpublishConfirmation-ConfirmButton"
+            >
+              Confirm
+            </button>
 
-                <CustomLink href={backHref}>Cancel</CustomLink>
-              </div>
-            </FlexibleQuestionPageLayout>
+            <CustomLink href={backHref}>Cancel</CustomLink>
           </div>
-        </div>
+        </FlexibleQuestionPageLayout>
       </div>
     </>
   );
-};
-
-type PublishConfirmationPageProps = {
-  backHref: string;
-  formAction: string;
-  fieldErrors: ValidationError[];
-  csrfToken: string;
 };
 
 export default UnpublishConfirmationPage;

--- a/packages/admin/src/pages/build-application/[applicationId]/unpublish-confirmation.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/unpublish-confirmation.test.tsx
@@ -9,17 +9,6 @@ import NextGetServerSidePropsResponse from '../../../types/NextGetServerSideProp
 import { updateApplicationFormStatus } from '../../../services/ApplicationService';
 import { parseBody } from 'next/dist/server/api-utils/node';
 
-jest.mock('next/config', () => () => {
-  return {
-    serverRuntimeConfig: {
-      backendHost: 'http://localhost:8080',
-    },
-    publicRuntimeConfig: {
-      SUB_PATH: '/apply',
-      APPLICANT_DOMAIN: 'http://localhost:8080',
-    },
-  };
-});
 jest.mock('next/dist/server/api-utils/node');
 jest.mock('../../../services/ApplicationService');
 


### PR DESCRIPTION
## Description

[Ticket TMI2-499](https://technologyprogramme.atlassian.net/jira/software/projects/TMI2/boards/331?selectedIssue=TMI2-499)

Summary of the changes and the related issue. List any dependencies that are required for this change:
- Fixing the layout from 1/3rd to 2/3rds for the unpublish application admin page

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

Before:
<img width="1107" alt="Screenshot 2023-12-06 at 10 16 09" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/96f58fbb-ed92-4532-bb3e-87922e316ce0">

After:
<img width="1100" alt="Screenshot 2023-12-06 at 10 14 55" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/2bbb036c-16c8-4170-a561-dd9887b7564b">


# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
