### PR TITLE
TMI2-499: Fixing layout of unpublish advert page

### DIFF
--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/unpublish-confirmation.page.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/unpublish-confirmation.page.tsx
@@ -112,49 +112,44 @@ const UnpublishConfirmationPage = ({
       <CustomLink isBackButton href={backHref} />
 
       <div className="govuk-!-padding-top-7">
-        <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">
-            <FlexibleQuestionPageLayout
-              formAction={formAction}
-              fieldErrors={fieldErrors}
-              csrfToken={csrfToken}
-            >
-              <Radio
-                questionTitle="Are you sure you want to unpublish this advert?"
-                questionHintText={
-                  <div>
-                    <p className="govuk-body">
-                      Once unpublished, your advert will no longer appear on
-                      Find a grant.
-                    </p>
-                    <p className="govuk-body">
-                      If you used this service to build an application form that
-                      is linked to this advert, and you want to stop applicants
-                      from submitting, you need to unpublish the application
-                      form too.
-                    </p>
-                  </div>
-                }
-                fieldName="confirmation"
-                radioOptions={[
-                  { label: 'Yes, unpublish my advert', value: 'true' },
-                  {
-                    label: 'No, keep my advert on Find a grant',
-                    value: 'false',
-                  },
-                ]}
-                fieldErrors={fieldErrors}
-              />
-              <button
-                className="govuk-button"
-                data-module="govuk-button"
-                data-cy="cy_unpublishConfirmation-ConfirmButton"
-              >
-                Confirm
-              </button>
-            </FlexibleQuestionPageLayout>
-          </div>
-        </div>
+        <FlexibleQuestionPageLayout
+          formAction={formAction}
+          fieldErrors={fieldErrors}
+          csrfToken={csrfToken}
+        >
+          <Radio
+            questionTitle="Are you sure you want to unpublish this advert?"
+            questionHintText={
+              <div>
+                <p className="govuk-body">
+                  Once unpublished, your advert will no longer appear on Find a
+                  grant.
+                </p>
+                <p className="govuk-body">
+                  If you used this service to build an application form that is
+                  linked to this advert, and you want to stop applicants from
+                  submitting, you need to unpublish the application form too.
+                </p>
+              </div>
+            }
+            fieldName="confirmation"
+            radioOptions={[
+              { label: 'Yes, unpublish my advert', value: 'true' },
+              {
+                label: 'No, keep my advert on Find a grant',
+                value: 'false',
+              },
+            ]}
+            fieldErrors={fieldErrors}
+          />
+          <button
+            className="govuk-button"
+            data-module="govuk-button"
+            data-cy="cy_unpublishConfirmation-ConfirmButton"
+          >
+            Confirm
+          </button>
+        </FlexibleQuestionPageLayout>
       </div>
     </>
   );


### PR DESCRIPTION
## Description

[Ticket TMI2-499](https://technologyprogramme.atlassian.net/jira/software/projects/TMI2/boards/331?selectedIssue=TMI2-499)

Summary of the changes and the related issue. List any dependencies that are required for this change:
- Turns out the advert unpublish page also has the same layout issue - fixing from 1/3rd to 2/3rds

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

Before:
<img width="1169" alt="Screenshot 2023-12-06 at 12 21 20" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/adbd7b33-62f7-427c-9e95-70e666401a4a">


After:
<img width="1177" alt="Screenshot 2023-12-06 at 12 21 09" src="https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/9d8dff20-9be0-4f2e-ad3a-6b0d8753a2d9">


# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
