### PR TITLE
fix api folder causing buggy behaviour

### DIFF
--- a/packages/admin/src/utils/general.ts
+++ b/packages/admin/src/utils/general.ts
@@ -31,7 +31,7 @@ type GetLoginUrlOptions = {
 const getLoginUrl = (options?: GetLoginUrlOptions) => {
   const oneLoginEnabled = process.env.ONE_LOGIN_ENABLED === 'true';
   if (options?.redirectToApplicant && oneLoginEnabled) {
-    return `${process.env.USER_SERVICE_URL}/v2/login?redirectUrl=${process.env.APPLICANT_DOMAIN}/api/isNewApplicant`;
+    return `${process.env.USER_SERVICE_URL}/v2/login?redirectUrl=${process.env.APPLICANT_DOMAIN}/dashboard`;
   }
   return oneLoginEnabled ? process.env.V2_LOGIN_URL : process.env.LOGIN_URL;
 };

--- a/packages/applicant/.env.example
+++ b/packages/applicant/.env.example
@@ -15,6 +15,7 @@ ONE_LOGIN_ENABLED=false
 V2_LOGIN_URL=http://localhost:8082/v2/login?redirectUrl=http://localhost:3000/apply/applicant/isAdmin
 V2_LOGOUT_URL=http://localhost:8082/v2/logout
 JWT_COOKIE_NAME=user-service-token
+SESSION_COOKIE_NAME=session_id
 ONE_LOGIN_MIGRATION_JOURNEY_ENABLED=false
 ONE_LOGIN_SECURITY_URL=https://home.integration.account.gov.uk/security
 ONE_LOGIN_ENABLED_IN_FIND=false

--- a/packages/applicant/src/components/partials/Header.tsx
+++ b/packages/applicant/src/components/partials/Header.tsx
@@ -104,7 +104,11 @@ const Header: FC<HeaderProps> = ({ isUserLoggedIn, oneLoginEnabledInFind }) => {
         >
           {isUserLoggedIn ? (
             <Link href={'/api/logout'}>
-              <a className="govuk-link govuk-link--no-visited-state">
+              <a
+                className="govuk-link govuk-link--no-visited-state"
+                type="button"
+                data-module="govuk-button"
+              >
                 Sign out
               </a>
             </Link>

--- a/packages/applicant/src/components/partials/Header.tsx
+++ b/packages/applicant/src/components/partials/Header.tsx
@@ -104,11 +104,7 @@ const Header: FC<HeaderProps> = ({ isUserLoggedIn, oneLoginEnabledInFind }) => {
         >
           {isUserLoggedIn ? (
             <Link href={'/api/logout'}>
-              <a
-                className="govuk-link govuk-link--no-visited-state"
-                type="button"
-                data-module="govuk-button"
-              >
+              <a className="govuk-link govuk-link--no-visited-state">
                 Sign out
               </a>
             </Link>

--- a/packages/applicant/src/pages/api/create-submission.page.tsx
+++ b/packages/applicant/src/pages/api/create-submission.page.tsx
@@ -1,15 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { GrantApplicantOrganisationProfile } from '../../../../types/models/GrantApplicantOrganisationProfile';
-import { GrantApplicantOrganisationProfileService } from '../../../../services/GrantApplicantOrganisationProfileService';
-import { GrantApplicantService } from '../../../../services/GrantApplicantService';
+import { GrantApplicantOrganisationProfile } from '../../types/models/GrantApplicantOrganisationProfile';
+import { GrantApplicantOrganisationProfileService } from '../../services/GrantApplicantOrganisationProfileService';
+import { GrantApplicantService } from '../../services/GrantApplicantService';
 import {
   GrantMandatoryQuestionDto,
   GrantMandatoryQuestionService,
-} from '../../../../services/GrantMandatoryQuestionService';
-import { createSubmission } from '../../../../services/SubmissionService';
-import { getJwtFromCookies } from '../../../../utils/jwt';
-import { routes } from '../../../../utils/routes';
-import { GrantSchemeService } from '../../../../services/GrantSchemeService';
+} from '../../services/GrantMandatoryQuestionService';
+import { createSubmission } from '../../services/SubmissionService';
+import { getJwtFromCookies } from '../../utils/jwt';
+import { routes } from '../../utils/routes';
+import { GrantSchemeService } from '../../services/GrantSchemeService';
 
 export default async function handler(
   req: NextApiRequest,
@@ -21,11 +21,9 @@ export default async function handler(
   const grantApplicantOrganisationProfileService =
     GrantApplicantOrganisationProfileService.getInstance();
   const grantSchemeService = GrantSchemeService.getInstance();
-
   const mandatoryQuestionId = req.query.mandatoryQuestionId.toString();
   const schemeId = req.query.schemeId.toString();
   const jwt = getJwtFromCookies(req);
-
   try {
     const grantApplicant = await grantApplicantService.getGrantApplicant(jwt);
     const mandatoryQuestionData =
@@ -35,7 +33,6 @@ export default async function handler(
       );
     const { grantApplication, grantAdverts } =
       await grantSchemeService.getGrantSchemeById(schemeId.toString(), jwt);
-
     const updateOrganisationDetailsDto = mapUpdateOrganisationDetailsDto(
       grantApplicant.organisation,
       mandatoryQuestionData
@@ -44,7 +41,6 @@ export default async function handler(
       updateOrganisationDetailsDto,
       jwt
     );
-
     if (!grantApplication.id) {
       await grantMandatoryQuestionService.updateMandatoryQuestion(
         jwt,
@@ -60,9 +56,7 @@ export default async function handler(
         )}?url=${grantAdverts[0].externalSubmissionUrl}`
       );
     }
-
     const { submissionId } = await createSubmission(grantApplication.id, jwt);
-
     await grantMandatoryQuestionService.updateMandatoryQuestion(
       jwt,
       mandatoryQuestionId,
@@ -72,12 +66,10 @@ export default async function handler(
         mandatoryQuestionsComplete: true,
       }
     );
-
     console.info(
       'Submission has been added to mandatory question: ',
       mandatoryQuestionId
     );
-
     return res.redirect(
       `${process.env.HOST}${routes.submissions.sections(submissionId)}`
     );

--- a/packages/applicant/src/pages/api/create-submission.page.tsx
+++ b/packages/applicant/src/pages/api/create-submission.page.tsx
@@ -21,9 +21,11 @@ export default async function handler(
   const grantApplicantOrganisationProfileService =
     GrantApplicantOrganisationProfileService.getInstance();
   const grantSchemeService = GrantSchemeService.getInstance();
+
   const mandatoryQuestionId = req.query.mandatoryQuestionId.toString();
   const schemeId = req.query.schemeId.toString();
   const jwt = getJwtFromCookies(req);
+
   try {
     const grantApplicant = await grantApplicantService.getGrantApplicant(jwt);
     const mandatoryQuestionData =
@@ -33,6 +35,7 @@ export default async function handler(
       );
     const { grantApplication, grantAdverts } =
       await grantSchemeService.getGrantSchemeById(schemeId.toString(), jwt);
+
     const updateOrganisationDetailsDto = mapUpdateOrganisationDetailsDto(
       grantApplicant.organisation,
       mandatoryQuestionData
@@ -41,6 +44,7 @@ export default async function handler(
       updateOrganisationDetailsDto,
       jwt
     );
+
     if (!grantApplication.id) {
       await grantMandatoryQuestionService.updateMandatoryQuestion(
         jwt,
@@ -56,7 +60,9 @@ export default async function handler(
         )}?url=${grantAdverts[0].externalSubmissionUrl}`
       );
     }
+
     const { submissionId } = await createSubmission(grantApplication.id, jwt);
+
     await grantMandatoryQuestionService.updateMandatoryQuestion(
       jwt,
       mandatoryQuestionId,
@@ -66,10 +72,12 @@ export default async function handler(
         mandatoryQuestionsComplete: true,
       }
     );
+
     console.info(
       'Submission has been added to mandatory question: ',
       mandatoryQuestionId
     );
+
     return res.redirect(
       `${process.env.HOST}${routes.submissions.sections(submissionId)}`
     );

--- a/packages/applicant/src/pages/api/create-submission.test.tsx
+++ b/packages/applicant/src/pages/api/create-submission.test.tsx
@@ -21,12 +21,12 @@ import handler from './create-submission.page';
 import { GrantAdvert } from '../../types/models/GrantAdvert';
 import { GrantSchemeService } from '../../services/GrantSchemeService';
 
-jest.mock('../../../../services/SubmissionService');
-jest.mock('../../../../services/GrantMandatoryQuestionService.ts');
-jest.mock('../../../../services/GrantApplicantService');
-jest.mock('../../../../services/GrantApplicantOrganisationProfileService');
-jest.mock('../../../../utils/jwt');
-jest.mock('../../../../services/GrantSchemeService');
+jest.mock('../../services/SubmissionService');
+jest.mock('../../services/GrantMandatoryQuestionService.ts');
+jest.mock('../../services/GrantApplicantService');
+jest.mock('../../services/GrantApplicantOrganisationProfileService');
+jest.mock('../../utils/jwt');
+jest.mock('../../services/GrantSchemeService');
 
 const APPLICANT_ID = '75ab5fbd-0682-4d3d-a467-01c7a447f07c';
 const MOCK_GRANT_APPLICANT: GrantApplicant = {

--- a/packages/applicant/src/pages/api/create-submission.test.tsx
+++ b/packages/applicant/src/pages/api/create-submission.test.tsx
@@ -1,25 +1,25 @@
 import { merge } from 'lodash';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { GrantApplicant } from '../../../../types/models/GrantApplicant';
+import { GrantApplicant } from '../../types/models/GrantApplicant';
 import {
   GrantApplicantOrganisationProfileService,
   UpdateOrganisationDetailsDto,
-} from '../../../../services/GrantApplicantOrganisationProfileService';
-import { GrantApplicantService } from '../../../../services/GrantApplicantService';
+} from '../../services/GrantApplicantOrganisationProfileService';
+import { GrantApplicantService } from '../../services/GrantApplicantService';
 import {
   GrantMandatoryQuestionDto,
   GrantMandatoryQuestionService,
-} from '../../../../services/GrantMandatoryQuestionService';
+} from '../../services/GrantMandatoryQuestionService';
 import {
   CreateSubmissionResponse,
   createSubmission,
-} from '../../../../services/SubmissionService';
-import { Overrides } from '../../../../testUtils/unitTestHelpers';
-import { getJwtFromCookies } from '../../../../utils/jwt';
-import { routes } from '../../../../utils/routes';
+} from '../../services/SubmissionService';
+import { Overrides } from '../../testUtils/unitTestHelpers';
+import { getJwtFromCookies } from '../../utils/jwt';
+import { routes } from '../../utils/routes';
 import handler from './create-submission.page';
-import { GrantAdvert } from '../../../../types/models/GrantAdvert';
-import { GrantSchemeService } from '../../../../services/GrantSchemeService';
+import { GrantAdvert } from '../../types/models/GrantAdvert';
+import { GrantSchemeService } from '../../services/GrantSchemeService';
 
 jest.mock('../../../../services/SubmissionService');
 jest.mock('../../../../services/GrantMandatoryQuestionService.ts');

--- a/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-summary.page.test.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-summary.page.test.tsx
@@ -128,7 +128,7 @@ describe('Organisation summary page', () => {
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute(
       'href',
-      `/api/mandatory-questions/mandatoryQuestionId/create-submission?schemeId=1`
+      `/api/create-submission?schemeId=1&mandatoryQuestionId=mandatoryQuestionId`
     );
   });
 });

--- a/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-summary.page.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/[mandatoryQuestionId]/organisation-summary.page.tsx
@@ -172,16 +172,18 @@ export default function MandatoryQuestionOrganisationSummaryPage({
             </dl>
 
             <Link
-              href={routes.api.mandatoryQuestions.createSubmission(
-                mandatoryQuestionId,
-                mandatoryQuestion.schemeId.toString()
-              )}
+              href={{
+                pathname: `/api/create-submission`,
+                query: {
+                  schemeId: mandatoryQuestion.schemeId.toString(),
+                  mandatoryQuestionId,
+                },
+              }}
             >
               <a
                 className="govuk-button"
                 data-module="govuk-button"
                 aria-disabled="false"
-                type="button"
               >
                 Confirm and submit
               </a>

--- a/packages/applicant/src/utils/routes.test.tsx
+++ b/packages/applicant/src/utils/routes.test.tsx
@@ -68,21 +68,6 @@ describe('api', () => {
       expect(routes.api.createMandatoryQuestion(schemeId)).toBe(expectedURL);
     });
   });
-  describe('api.mandatoryQuestions', () => {
-    describe('Api.mandatoryQuestions.createSubmission', () => {
-      it('should generate the correct URL', () => {
-        const schemeId = 'schemeId';
-        const mandatoryQuestionId = 'exampleMandatoryQuestionId';
-        const expectedURL = `/api/mandatory-questions/${mandatoryQuestionId}/create-submission?schemeId=${schemeId}`;
-        expect(
-          routes.api.mandatoryQuestions.createSubmission(
-            mandatoryQuestionId,
-            schemeId
-          )
-        ).toBe(expectedURL);
-      });
-    });
-  });
   describe('isNewApplicant', () => {
     describe('isNewApplicant.index', () => {
       it('should generate the correct URL when migrationStatus is present', () => {

--- a/packages/applicant/src/utils/routes.tsx
+++ b/packages/applicant/src/utils/routes.tsx
@@ -81,10 +81,6 @@ export const routes = {
     },
     createMandatoryQuestion: (schemeId: string) =>
       `/api/create-mandatory-question?schemeId=${schemeId}`,
-    mandatoryQuestions: {
-      createSubmission: (mandatoryQuestionId: string, schemeId: string) =>
-        `/api/mandatory-questions/${mandatoryQuestionId}/create-submission?schemeId=${schemeId}`,
-    },
   },
 };
 


### PR DESCRIPTION
## Description

Due to what seems to be a bug with Nextjs 12.3.4 having identically named subfolders in both `/pages` and `/page/api` directories causes Nextjs to mistakenly treat the latter as pages, meaning the redirects from these API routes are not respected.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
