### PR TITLE
Passing in pageData to handleRequest function

### DIFF
--- a/packages/admin/src/utils/QuestionPageGetServerSideProps.test.tsx
+++ b/packages/admin/src/utils/QuestionPageGetServerSideProps.test.tsx
@@ -145,7 +145,8 @@ describe('QuestionPageGetServerSideProps', () => {
         {
           '1': 'testNewResponse',
         },
-        'testSessionId'
+        'testSessionId',
+        { '1': 'testResponse' }
       );
     });
 

--- a/packages/admin/src/utils/QuestionPageGetServerSideProps.tsx
+++ b/packages/admin/src/utils/QuestionPageGetServerSideProps.tsx
@@ -47,6 +47,7 @@ export default async function QuestionPageGetServerSideProps<
   const postResponse = await postPagesResult({
     ...props,
     ...context,
+    pageData,
   });
 
   if (postResponse && 'redirect' in postResponse) {
@@ -86,7 +87,11 @@ async function fetchAndHandlePageData<K extends FetchPageData>(
   }
 }
 
-async function postPagesResult<T extends PageBodyResponse, V>({
+async function postPagesResult<
+  T extends PageBodyResponse,
+  K extends FetchPageData,
+  V
+>({
   req,
   res,
   handleRequest,
@@ -94,11 +99,12 @@ async function postPagesResult<T extends PageBodyResponse, V>({
   onSuccessRedirectHref,
   onErrorMessage,
   resolvedUrl,
-}: PostPageResultProps<T, V>) {
+  pageData,
+}: PostPageResultProps<T, K, V>) {
   return CallServiceMethod<T, V>(
     req,
     res,
-    (body) => handleRequest(body, jwt),
+    (body) => handleRequest(body, jwt, pageData),
     onSuccessRedirectHref,
     generateServiceErrorProps(onErrorMessage, resolvedUrl)
   );

--- a/packages/admin/src/utils/QuestionPageGetServerSidePropsTypes.ts
+++ b/packages/admin/src/utils/QuestionPageGetServerSidePropsTypes.ts
@@ -4,23 +4,32 @@ import { ValidationError } from 'gap-web-ui';
 export type PageBodyResponse = Record<string, string | string[]>;
 export type FetchPageData = Record<string, any>;
 
-export type QuestionPageGetServerSidePropsType<T, K, V> = {
+export type QuestionPageGetServerSidePropsType<
+  T extends PageBodyResponse,
+  K extends FetchPageData,
+  V
+> = {
   context: GetServerSidePropsContext;
   fetchPageData: (jwt: string) => Promise<K>;
-  handleRequest: (body: T, jwt: string) => Promise<V>;
+  handleRequest: (body: T, jwt: string, pageData: K) => Promise<V>;
   jwt: string;
   onSuccessRedirectHref: string | ((result: V) => string);
   onErrorMessage: string;
 };
 
-export type PostPageResultProps<T extends PageBodyResponse, V> = {
+export type PostPageResultProps<
+  T extends PageBodyResponse,
+  K extends FetchPageData,
+  V
+> = {
   req: GetServerSidePropsContext['req'];
   res: GetServerSidePropsContext['res'];
-  handleRequest: (body: T, jwt: string) => Promise<V>;
+  handleRequest: (body: T, jwt: string, pageData: K) => Promise<V>;
   onSuccessRedirectHref: string | ((result: V) => string);
   jwt: string;
   onErrorMessage: string;
   resolvedUrl: string;
+  pageData: K;
 };
 
 export type generateValidationPropsType<T> =


### PR DESCRIPTION
When using `QuestionPageGetServerSideProps`, allows for the use of pageData within the handleRequest function & supports all the generic typing.

![Screenshot 2023-12-13 at 16 30 33](https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/6352cb96-16fe-4856-99ce-316f186e0600)
![Screenshot 2023-12-13 at 16 31 19](https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/361c7338-2586-46f1-86d9-a35f5b6c2430)



E.g.
``` 
  async function handleRequest(
    body: PageBodyResponse,
    jwt: string,
    pageData: Awaited<ReturnType<typeof fetchPageData>>
  ) {
    console.log(pageData);
    await checkNewAdminEmailIsValid(
      jwt,
      getUserTokenFromCookies(context.req),
      body.emailAddress,
      oldEmailAddress
    );
    return body.emailAddress;
  }