### PR TITLE
TD-150: redirects user if eligibility sections response is no

### DIFF
--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
-import { ValidationError } from 'gap-web-ui';
+import { ValidationError, expectObjectEquals } from 'gap-web-ui';
 import { GetServerSidePropsContext } from 'next';
 import { parseBody } from 'next/dist/server/api-utils/node';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
@@ -8,6 +8,7 @@ import {
   SectionData,
   SectionReviewBody,
   getSectionById,
+  isApplicantEligible,
   postHasSectionBeenCompleted,
 } from '../../../../../services/SubmissionService';
 import { createMockRouter } from '../../../../../testUtils/createMockRouter';
@@ -157,6 +158,7 @@ describe('getServerSideProps', () => {
   it('should return sections and expected props', async () => {
     (getSectionById as jest.Mock).mockReturnValue(SECTION_MOCK);
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
       spiedGetMandatoryQuestionBySubmissionId,
       mockMandatoryQuestionDto
@@ -185,6 +187,7 @@ describe('getServerSideProps', () => {
   it('should return sections and expected props with no csrf Token', async () => {
     (getSectionById as jest.Mock).mockReturnValue(SECTION_MOCK);
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
       spiedGetMandatoryQuestionBySubmissionId,
       mockMandatoryQuestionDto
@@ -233,6 +236,7 @@ describe('getServerSideProps', () => {
 
     (getSectionById as jest.Mock).mockReturnValue(SECTION_MOCK);
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
       spiedGetMandatoryQuestionBySubmissionId,
       mockMandatoryQuestionDto
@@ -281,6 +285,7 @@ describe('getServerSideProps', () => {
 
     (getSectionById as jest.Mock).mockReturnValue(SECTION_MOCK);
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
       spiedGetMandatoryQuestionBySubmissionId,
       mockMandatoryQuestionDto
@@ -342,6 +347,7 @@ describe('getServerSideProps', () => {
     (getSectionById as jest.Mock).mockReturnValue(SECTION_MOCK);
     (parseBody as jest.Mock).mockResolvedValue(requestBody);
     (postHasSectionBeenCompleted as jest.Mock).mockReturnValue(acceptedValue);
+    (isApplicantEligible as jest.Mock).mockReturnValue(true);
     const response = (await getServerSideProps(
       ctx as any
     )) as NextGetServerSidePropsResponse;
@@ -392,10 +398,25 @@ describe('getServerSideProps', () => {
     (getSectionById as jest.Mock).mockReturnValue(SECTION_MOCK);
     (parseBody as jest.Mock).mockResolvedValue(requestBody);
     (postHasSectionBeenCompleted as jest.Mock).mockRejectedValue(rejectedValue);
+    (isApplicantEligible as jest.Mock).mockReturnValue(true);
     const response = (await getServerSideProps(
       ctx as any
     )) as NextGetServerSidePropsResponse;
     expect(response).toEqual(expectedProps);
+  });
+
+  it('Should redirect to sections if eligibility response is set to No', async () => {
+    (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (isApplicantEligible as jest.Mock).mockReturnValue(false);
+
+    const response = await getServerSideProps(context);
+
+    expectObjectEquals(response, {
+      redirect: {
+        permanent: false,
+        destination: '/submissions/12345678/sections',
+      },
+    });
   });
 });
 

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
-import { ValidationError, expectObjectEquals } from 'gap-web-ui';
+import { ValidationError } from 'gap-web-ui';
 import { GetServerSidePropsContext } from 'next';
 import { parseBody } from 'next/dist/server/api-utils/node';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
@@ -411,7 +411,7 @@ describe('getServerSideProps', () => {
 
     const response = await getServerSideProps(context);
 
-    expectObjectEquals(response, {
+    expect(response).toEqual({
       redirect: {
         permanent: false,
         destination: '/submissions/12345678/sections',

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.tsx
@@ -10,6 +10,7 @@ import {
   SectionData,
   SectionReviewBody,
   getSectionById,
+  isApplicantEligible,
   postHasSectionBeenCompleted,
 } from '../../../../../services/SubmissionService';
 import callServiceMethod from '../../../../../utils/callServiceMethod';
@@ -97,6 +98,18 @@ export const getServerSideProps: GetServerSideProps<SectionRecapPage> = async ({
   const backButtonUrl = `/submissions/${submissionId}/sections`;
   const sectionId = params.sectionId.toString();
   const jwt = getJwtFromCookies(req);
+
+  if (sectionId != 'ELIGIBILITY') {
+    const isEligible = await isApplicantEligible(submissionId, jwt);
+    if (!isEligible) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: `/submissions/${submissionId}/sections`,
+        },
+      };
+    }
+  }
 
   const isOrganisationDetailsOrFunding =
     sectionId === 'ORGANISATION_DETAILS' || sectionId === 'FUNDING_DETAILS';

--- a/packages/applicant/src/services/SubmissionService.test.ts
+++ b/packages/applicant/src/services/SubmissionService.test.ts
@@ -3,6 +3,13 @@ import MockAdapter from 'axios-mock-adapter';
 import getConfig from 'next/config';
 import { axiosConfig } from '../utils/jwt';
 import {
+  NextNavigation,
+  PostQuestionResponse,
+  QuestionData,
+  QuestionPostBody,
+  QuestionType,
+  SectionData,
+  SectionReviewBody,
   createSubmission,
   deleteAttachmentByQuestionId,
   getNextNavigation,
@@ -10,17 +17,11 @@ import {
   getSectionById,
   getSubmissionById,
   hasSubmissionBeenSubmitted,
+  isApplicantEligible,
   isSubmissionReady,
-  NextNavigation,
   postDocumentResponse,
   postHasSectionBeenCompleted,
   postQuestionResponse,
-  PostQuestionResponse,
-  QuestionData,
-  QuestionPostBody,
-  QuestionType,
-  SectionData,
-  SectionReviewBody,
   submit,
 } from './SubmissionService';
 
@@ -46,6 +47,7 @@ const MockCreateSubmissionData = [
     message: 'string',
   },
 ];
+const getIsApplicantEligibleUrl = `${BACKEND_HOST}/submissions/${submissionId}/isApplicantEligible`;
 const getIsApplicationReadyByUrl = `${BACKEND_HOST}/submissions/${submissionId}/ready`;
 const getHasSubmissionBeenSubmittedUrl = `${BACKEND_HOST}/submissions/${submissionId}/isSubmitted`;
 const postSubmitUrl = `${BACKEND_HOST}/submissions/submit`;
@@ -675,5 +677,45 @@ describe('postHasSectionBeenCompleted', () => {
         },
       }
     );
+  });
+});
+
+describe('isApplicantEligible', () => {
+  test('should return true is applicant has selected yes for eligibility section', async () => {
+    const spy = jest.spyOn(axios, 'get');
+    const mock = new MockAdapter(axios);
+    const expectedResult = true;
+    (axiosConfig as jest.Mock).mockReturnValue(mockAxiosConfig);
+
+    mock.onGet(getIsApplicantEligibleUrl).reply(200, expectedResult);
+
+    const result = await isApplicantEligible(submissionId, 'testJwt');
+
+    expect(result).toEqual(expectedResult);
+    expect(spy).toBeCalledWith(getIsApplicantEligibleUrl, {
+      headers: {
+        Authorization: `Bearer testJwt`,
+        Accept: 'application/json',
+      },
+    });
+  });
+
+  test('should return false is applicant has selected yes for eligibility section', async () => {
+    const spy = jest.spyOn(axios, 'get');
+    const mock = new MockAdapter(axios);
+    const expectedResult = false;
+    (axiosConfig as jest.Mock).mockReturnValue(mockAxiosConfig);
+
+    mock.onGet(getIsApplicantEligibleUrl).reply(200, expectedResult);
+
+    const result = await isApplicantEligible(submissionId, 'testJwt');
+
+    expect(result).toEqual(expectedResult);
+    expect(spy).toBeCalledWith(getIsApplicantEligibleUrl, {
+      headers: {
+        Authorization: `Bearer testJwt`,
+        Accept: 'application/json',
+      },
+    });
   });
 });

--- a/packages/applicant/src/services/SubmissionService.tsx
+++ b/packages/applicant/src/services/SubmissionService.tsx
@@ -175,6 +175,17 @@ export async function getNextNavigation(
   return data;
 }
 
+export async function isApplicantEligible(
+  submissionId: string,
+  jwt: string
+): Promise<boolean> {
+  const { data } = await axios.get<boolean>(
+    `${BACKEND_HOST}/submissions/${submissionId}/isApplicantEligible`,
+    axiosConfig(jwt)
+  );
+  return data;
+}
+
 export interface SectionReviewBody {
   isComplete: boolean;
 }


### PR DESCRIPTION
## Description
Makes call to backend to check the eligibility response on submission sections overview page. False is returned if the response is 'No' and the user will not be able to submit the application or fill out the other sections. Even if the user tries to navigate to these sections through the URL, they will be redirected to the submission sections overview page.

Ticket # and link
TD-150: https://technologyprogramme.atlassian.net/browse/TD-150

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
