### PR TITLE
TMI2-522 - Added logic to redirect applicant without valid session-id cookie

### DIFF
--- a/packages/admin/src/middleware.page.ts
+++ b/packages/admin/src/middleware.page.ts
@@ -20,7 +20,8 @@ export async function middleware(req: NextRequest) {
   const rewriteUrl = req.url;
   const res = NextResponse.rewrite(rewriteUrl);
   const auth_cookie = req.cookies.get('session_id');
-
+  const user_service_cookie = req.cookies.get('user-service-token');
+  console.log('user_service_cookie', user_service_cookie);
   //Feature flag redirects
   const advertBuilderPath = /\/scheme\/\d*\/advert/;
 
@@ -54,6 +55,11 @@ export async function middleware(req: NextRequest) {
     res.headers.set('Cache-Control', 'no-store');
 
     return res;
+  } else if (user_service_cookie !== undefined) {
+    console.log('triggered');
+    return NextResponse.redirect(getLoginUrl({ redirectToApplicant: true }), {
+      status: 302,
+    });
   } else {
     return NextResponse.redirect(getLoginUrl());
   }

--- a/packages/admin/src/middleware.page.ts
+++ b/packages/admin/src/middleware.page.ts
@@ -21,7 +21,6 @@ export async function middleware(req: NextRequest) {
   const res = NextResponse.rewrite(rewriteUrl);
   const auth_cookie = req.cookies.get('session_id');
   const user_service_cookie = req.cookies.get('user-service-token');
-  console.log('user_service_cookie', user_service_cookie);
   //Feature flag redirects
   const advertBuilderPath = /\/scheme\/\d*\/advert/;
 
@@ -56,7 +55,6 @@ export async function middleware(req: NextRequest) {
 
     return res;
   } else if (user_service_cookie !== undefined) {
-    console.log('triggered');
     return NextResponse.redirect(getLoginUrl({ redirectToApplicant: true }), {
       status: 302,
     });


### PR DESCRIPTION
## Description

[Dashboard link not working for applicant on 404 error page](https://technologyprogramme.atlassian.net/jira/software/projects/TMI2/boards/331?selectedIssue=TMI2-522)

Admin middleware required additional logic to redirect an applicant attempting to access admin pages. The error page in the ticket should never be accessible to an applicant as it is the **admin** error page (hence the dashboard link not working - the admin error page is trying to redirect to the admin dashboard).

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):


https://github.com/cabinetoffice/gap-find-apply-web/assets/107405237/734fe279-7c0a-4abb-ad3d-72fc58a9adad



# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
