### PR TITLE
GAP-2365: Throwing error if application has been unpublished

### DIFF
--- a/packages/applicant/src/pages/mandatory-questions/start.page.test.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/start.page.test.tsx
@@ -161,7 +161,7 @@ describe('Mandatory Questions Start', () => {
 
       expect(response).toEqual({
         redirect: {
-          destination: `/service-error?serviceErrorProps={"errorInformation":"This application has been unpublished.","linkAttributes":{"href":"/","linkText":"Go back to the home page","linkInformation":""}}`,
+          destination: `/grant-is-closed`,
           permanent: false,
         },
       });

--- a/packages/applicant/src/pages/mandatory-questions/start.page.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/start.page.tsx
@@ -6,6 +6,7 @@ import { GrantMandatoryQuestionService } from '../../services/GrantMandatoryQues
 import InferProps from '../../types/InferProps';
 import { getJwtFromCookies } from '../../utils/jwt';
 import { routes } from '../../utils/routes';
+import { getApplicationStatusBySchemeId } from '../../services/ApplicationService';
 
 export async function getServerSideProps({
   req,
@@ -44,6 +45,22 @@ export async function getServerSideProps({
       },
     };
   }
+  try {
+    const applicationStatus = await getApplicationStatusBySchemeId(
+      schemeId,
+      jwt
+    );
+    if (applicationStatus === 'REMOVED') {
+      return {
+        redirect: {
+          destination: `/service-error?serviceErrorProps={"errorInformation":"This application has been unpublished.","linkAttributes":{"href":"/","linkText":"Go back to the home page","linkInformation":""}}`,
+          permanent: false,
+        },
+      };
+    }
+  } catch (error) {
+    // External application form - do nothing
+  }
   return {
     props: {
       schemeId,
@@ -53,10 +70,11 @@ export async function getServerSideProps({
 
 export default function MandatoryQuestionsBeforeYouStart({
   schemeId,
-}: InferProps<typeof getServerSideProps>) {
+}: Readonly<InferProps<typeof getServerSideProps>>) {
   return (
     <>
       <Meta title="Before you start" />
+
       <Layout>
         <h1 className="govuk-heading-l">Before you start</h1>
         <p className="govuk-body">

--- a/packages/applicant/src/pages/mandatory-questions/start.page.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/start.page.tsx
@@ -45,21 +45,14 @@ export async function getServerSideProps({
       },
     };
   }
-  try {
-    const applicationStatus = await getApplicationStatusBySchemeId(
-      schemeId,
-      jwt
-    );
-    if (applicationStatus === 'REMOVED') {
-      return {
-        redirect: {
-          destination: `/service-error?serviceErrorProps={"errorInformation":"This application has been unpublished.","linkAttributes":{"href":"/","linkText":"Go back to the home page","linkInformation":""}}`,
-          permanent: false,
-        },
-      };
-    }
-  } catch (error) {
-    // External application form - do nothing
+  const applicationStatus = await getApplicationStatusBySchemeId(schemeId, jwt);
+  if (applicationStatus === 'REMOVED') {
+    return {
+      redirect: {
+        destination: '/grant-is-closed',
+        permanent: false,
+      },
+    };
   }
   return {
     props: {


### PR DESCRIPTION
## Description

Ticket [GAP-2365](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2365)

Summary of the changes and the related issue. List any dependencies that are required for this change:
- When an application status is REMOVED (unpublished), then throwing an error before starting MQ journey
- https://github.com/cabinetoffice/gap-find-applicant-backend/pull/87

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:



https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/bea658b8-c150-4404-9720-c1d77ef4f998




# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2365]: https://technologyprogramme.atlassian.net/browse/GAP-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ