### PR TITLE
TMI2-515 - Fixed line breaks in advert summary page on Safari

### DIFF
--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/components/List.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/components/List.tsx
@@ -45,7 +45,7 @@ export function List({
         className="govuk-summary-list__key"
         data-cy={`cy-summary-${section.title}-${question.title}`}
       >
-        {question.title}
+        <div>{question.title}</div>
       </dt>
 
       <dd
@@ -57,13 +57,15 @@ export function List({
 
       {isGrantAdvertNotPublished(status) && (
         <dd className="govuk-summary-list__actions">
-          <CustomLink
-            href={`/scheme/${schemeId}/advert/${advertId}/${section.id}/${page.id}`}
-            dataCy={`cy-summary-${section.title}-${question.title}-change`}
-            ariaLabel={`${actionText} response for ${question.title} question`}
-          >
-            {actionText}
-          </CustomLink>
+          <div>
+            <CustomLink
+              href={`/scheme/${schemeId}/advert/${advertId}/${section.id}/${page.id}`}
+              dataCy={`cy-summary-${section.title}-${question.title}-change`}
+              ariaLabel={`${actionText} response for ${question.title} question`}
+            >
+              {actionText}
+            </CustomLink>
+          </div>
         </dd>
       )}
     </div>

--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/components/RichText.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/components/RichText.tsx
@@ -73,7 +73,7 @@ export function RichText({
         className="govuk-summary-list__key"
         data-cy={`cy-summary-${section.title}-${question.title}`}
       >
-        {question.title}
+        <div>{question.title}</div>
       </dt>
       <dd
         className="govuk-summary-list__value"
@@ -84,13 +84,15 @@ export function RichText({
 
       {isGrantAdvertNotPublished(status) && (
         <dd className="govuk-summary-list__actions">
-          <CustomLink
-            href={`/scheme/${schemeId}/advert/${advertId}/${section.id}/${page.id}`}
-            dataCy={`cy-summary-${section.title}-${question.title}-change`}
-            ariaLabel={`${actionText} response for ${question.title} question`}
-          >
-            {actionText}
-          </CustomLink>
+          <div>
+            <CustomLink
+              href={`/scheme/${schemeId}/advert/${advertId}/${section.id}/${page.id}`}
+              dataCy={`cy-summary-${section.title}-${question.title}-change`}
+              ariaLabel={`${actionText} response for ${question.title} question`}
+            >
+              {actionText}
+            </CustomLink>
+          </div>
         </dd>
       )}
     </div>


### PR DESCRIPTION
## Description

[TMI2-515 - Admin summary page doesn't look right on safari](https://technologyprogramme.atlassian.net/jira/software/projects/TMI2/boards/331?selectedIssue=TMI2-515)

Isolated the fields causing the rendering errors with divs. This causes no visible differences to rendering in Chrome while fixing the errors in Safari.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:


https://github.com/cabinetoffice/gap-find-apply-web/assets/107405237/59ca6542-2885-4a8f-8c62-baa82282ac10



# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
