### PR TITLE
TMI2-589 - Fixed line breaks in super admin department page on Safari

### DIFF
--- a/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.page.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.page.tsx
@@ -65,7 +65,7 @@ const getDepartmentRow = ({ id, name, ggisID = '' }: Department): Row => ({
   key: name,
   value: ggisID,
   action: (
-    <div className={styles['float-left-sm']}>
+    <div className={styles['text-align-left']}>
       <CustomLink href={`/super-admin-dashboard/manage-departments/edit/${id}`}>
         Edit
       </CustomLink>

--- a/packages/admin/src/pages/super-admin-dashboard/manage-departments/manage-departments.module.scss
+++ b/packages/admin/src/pages/super-admin-dashboard/manage-departments/manage-departments.module.scss
@@ -2,4 +2,8 @@
   .float-left-sm {
     float: left;
   }
+
+  .text-align-left {
+    text-align: left;
+  }
 }

--- a/packages/gap-web-ui/src/components/summary-list/SummaryList.tsx
+++ b/packages/gap-web-ui/src/components/summary-list/SummaryList.tsx
@@ -44,7 +44,7 @@ const SummaryList = ({
                }
             `}
             >
-              {row.key}
+              <div>{row.key}</div>
             </dt>
             <dd
               className={`govuk-summary-list__value${
@@ -52,7 +52,7 @@ const SummaryList = ({
               }`}
               data-cy={`cy_summaryListValue_${row.key}`}
             >
-              {row.value}
+              <div>{row.value}</div>
             </dd>
             {row.action && (
               <dd


### PR DESCRIPTION
## Description

[TMI2-589 - Super admin department list formatting strange on safari](https://technologyprogramme.atlassian.net/jira/software/projects/TMI2/boards/331?selectedIssue=TMI2-589)

Isolated the fields causing the rendering errors with divs. This causes no visible differences to rendering in Chrome while fixing the errors in Safari.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):


https://github.com/cabinetoffice/gap-find-apply-web/assets/107405237/da6b83e7-99b5-4366-bac5-3f64543608e8



# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
