### PR TITLE
GAP-2097: Download submission summary

### DIFF
--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/download-summary.page.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/download-summary.page.tsx
@@ -9,5 +9,8 @@ export default async function handler(
 ) {
   const submissionId = req.query.submissionId.toString();
   const { data } = await downloadSummary(submissionId, getJwtFromCookies(req));
+
+  res.setHeader('Content-Type', 'application/octet-stream');
+  res.setHeader('Content-Disposition', 'attachment; filename=submission.odt');
   res.send(Buffer.from(data));
 }

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/download-summary.page.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/download-summary.page.tsx
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { routes } from '../../../../../utils/routes';
+import { downloadSummary } from '../../../../../services/SubmissionService';
+import { getJwtFromCookies } from '../../../../../utils/jwt';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const submissionId = req.query.submissionId.toString();
+  const { data } = await downloadSummary(submissionId, getJwtFromCookies(req));
+  res.send(Buffer.from(data));
+}

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/download-summary.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/download-summary.test.tsx
@@ -1,0 +1,48 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import axios from 'axios';
+import handler from './download-summary.page';
+
+jest.mock('axios');
+jest.mock('../../../../../middleware.page');
+jest.mock('../../../../../utils/jwt');
+jest.mock('next/config', () => () => ({
+  serverRuntimeConfig: {
+    backendHost: 'http://localhost:1',
+  },
+}));
+
+describe('Next API Handler', () => {
+  it('should handle the request and send the file', async () => {
+    const submissionId = 'exampleSubmissionId';
+
+    (axios.get as jest.Mock).mockResolvedValue({
+      data: 'mocked file data',
+    });
+
+    const req = {
+      query: { submissionId },
+    } as unknown as NextApiRequest;
+
+    const res = {
+      setHeader: jest.fn(),
+      send: jest.fn(),
+    } as unknown as NextApiResponse;
+    await handler(req, res);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `http://localhost:1/submissions/${submissionId}/download-summary`,
+      { responseType: 'arraybuffer' }
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/octet-stream'
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename=submission.odt'
+    );
+    expect(res.send).toHaveBeenCalledWith(
+      Buffer.from('mocked file data', 'binary')
+    );
+  });
+});

--- a/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
@@ -153,7 +153,7 @@ export default function SubmissionSummary({
                   style={{ pointerEvents: 'none' }}
                   href={`/apply/applicant/api/routes/submissions/${grantSubmissionId}/download-summary`}
                 >
-                  download a copy of your answers (Zip)
+                  download a copy of your answers (Odt)
                 </a>{' '}
                 for future reference.
               </p>

--- a/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
@@ -150,10 +150,10 @@ export default function SubmissionSummary({
                 You can{' '}
                 <a
                   className="govuk-link govuk-link--no-visited-state"
-                  href={''}
                   style={{ pointerEvents: 'none' }}
+                  href={`/apply/applicant/api/routes/submissions/${grantSubmissionId}/download-summary`}
                 >
-                  download a copy of your answers (ODT)
+                  download a copy of your answers (Zip)
                 </a>{' '}
                 for future reference.
               </p>

--- a/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
@@ -148,13 +148,15 @@ export default function SubmissionSummary({
               </h1>
               <p className="govuk-body">
                 You can{' '}
-                <a
-                  className="govuk-link govuk-link--no-visited-state"
-                  style={{ pointerEvents: 'none' }}
-                  href={`/apply/applicant/api/routes/submissions/${grantSubmissionId}/download-summary`}
+                <Link
+                  href={routes.api.submissions.downloadSummary(
+                    grantSubmissionId
+                  )}
                 >
-                  download a copy of your answers (ODT)
-                </a>{' '}
+                  <a className="govuk-link govuk-link--no-visited-state">
+                    download a copy of your answers (ODT)
+                  </a>
+                </Link>{' '}
                 for future reference.
               </p>
 

--- a/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
@@ -153,7 +153,7 @@ export default function SubmissionSummary({
                   style={{ pointerEvents: 'none' }}
                   href={`/apply/applicant/api/routes/submissions/${grantSubmissionId}/download-summary`}
                 >
-                  download a copy of your answers (Odt)
+                  download a copy of your answers (ODT)
                 </a>{' '}
                 for future reference.
               </p>

--- a/packages/applicant/src/services/SubmissionService.tsx
+++ b/packages/applicant/src/services/SubmissionService.tsx
@@ -178,7 +178,7 @@ export async function getNextNavigation(
 export async function downloadSummary(submissionId, jwt) {
   return await axios.get(
     `${BACKEND_HOST}/submissions/${submissionId}/download-summary`,
-    axiosConfig(jwt)
+    { ...axiosConfig(jwt), responseType: 'arraybuffer' }
   );
 }
 

--- a/packages/applicant/src/services/SubmissionService.tsx
+++ b/packages/applicant/src/services/SubmissionService.tsx
@@ -175,6 +175,13 @@ export async function getNextNavigation(
   return data;
 }
 
+export async function downloadSummary(submissionId, jwt) {
+  return await axios.get(
+    `${BACKEND_HOST}/submissions/${submissionId}/download-summary`,
+    axiosConfig(jwt)
+  );
+}
+
 export async function isApplicantEligible(
   submissionId: string,
   jwt: string

--- a/packages/applicant/src/utils/routes.tsx
+++ b/packages/applicant/src/utils/routes.tsx
@@ -68,6 +68,8 @@ export const routes = {
     `/service-error?serviceErrorProps=${JSON.stringify(serviceErrorProps)}`,
   api: {
     submissions: {
+      downloadSummary: (submissionId: string) =>
+        `/api/routes/submissions/${submissionId}/download-summary`,
       section: (grantSubmissionId: string, sectionId: string) =>
         `/api/routes/submissions/${grantSubmissionId}/sections/${sectionId}`,
       question: (


### PR DESCRIPTION
## Description

Adds an api route which sends the odt submission summary to the browser

https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2097

related prs: 
- https://github.com/cabinetoffice/gap-user-service/pull/175
- https://github.com/cabinetoffice/gap-find-applicant-backend/pull/89




## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
