### PR TITLE
GAP-2360: Fix mandatory questions grant-is-closed journeys

### DIFF
--- a/packages/applicant/src/middleware.test.ts
+++ b/packages/applicant/src/middleware.test.ts
@@ -116,4 +116,33 @@ describe('Middleware', () => {
       `${process.env.HOST}/grant-is-closed`
     );
   });
+
+  it('redirect to grant-is-closed if it gets a removed response from the API for mandatory questions', async () => {
+    const req = new NextRequest(
+      new Request('https://some.website.com/mandatory-questions/000/some-url')
+    );
+
+    req.cookies.set(process.env.USER_TOKEN_NAME, 'valid');
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      text: jest.fn().mockResolvedValue('REMOVED'),
+    } as unknown as Response);
+    const res = await middleware(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe(
+      `${process.env.HOST}/grant-is-closed`
+    );
+  });
+
+  it('does not redirect to grant is closed if mandatory questions start page', async () => {
+    const req = new NextRequest(
+      new Request(
+        'https://some.website.com/mandatory-questions/start?=someuuid'
+      )
+    );
+
+    req.cookies.set(process.env.USER_TOKEN_NAME, 'valid');
+    const res = await middleware(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe(`${process.env.HOST}`);
+  });
 });

--- a/packages/applicant/src/pages/mandatory-questions/start.page.test.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/start.page.test.tsx
@@ -151,6 +151,21 @@ describe('Mandatory Questions Start', () => {
         },
       });
     });
+
+    it('should redirect if the application form status is REMOVED', async () => {
+      (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+      spiedExistBySchemeIdAndApplicantId.mockResolvedValue(false);
+      mockedGetApplicationStatusBySchemeId.mockResolvedValue('REMOVED');
+
+      const response = await getServerSideProps(getContext(getDefaultContext));
+
+      expect(response).toEqual({
+        redirect: {
+          destination: `/grant-is-closed`,
+          permanent: false,
+        },
+      });
+    });
   });
 
   describe('UI', () => {

--- a/packages/applicant/src/pages/mandatory-questions/start.page.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/start.page.tsx
@@ -46,6 +46,16 @@ export async function getServerSideProps({
     };
   }
   const applicationStatus = await getApplicationStatusBySchemeId(schemeId, jwt);
+
+  if (applicationStatus === 'REMOVED') {
+    return {
+      redirect: {
+        destination: '/grant-is-closed',
+        permanent: false,
+      },
+    };
+  }
+
   return {
     props: {
       schemeId,


### PR DESCRIPTION
## Description

Previous PR broke Mandatory Questions grant-is-closed logic as it was assuming it was a submission ID that is parse in the URL. This changes it to dynamically hit the backend based on if its a Question ID or a Submission ID

Ticket # and link
GAP:2360

Summary of the changes and the related issue. List any dependencies that are required for this change:

Dependent on https://github.com/cabinetoffice/gap-find-applicant-backend/pull/96
Implemented endpoint to function.


## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
