### PR TITLE
GAP-2360: Remove back button on grant-is-closed

### DIFF
--- a/packages/applicant/src/pages/grant-is-closed.page.test.tsx
+++ b/packages/applicant/src/pages/grant-is-closed.page.test.tsx
@@ -35,12 +35,4 @@ describe('Grant is closed page', () => {
       'https://www.find-government-grants.service.gov.uk/grants'
     );
   });
-
-  it('should render back link', () => {
-    expect(
-      screen.getByRole('link', {
-        name: /go back/i,
-      })
-    ).toHaveAttribute('href', `/dashboard`);
-  });
 });

--- a/packages/applicant/src/pages/grant-is-closed.page.tsx
+++ b/packages/applicant/src/pages/grant-is-closed.page.tsx
@@ -26,13 +26,6 @@ export default function GrantIsClosedPage() {
               >
                 Find a grant
               </a>
-
-              <a
-                className="govuk-link govuk-link--no-visited-state"
-                href="/dashboard"
-              >
-                Go back
-              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

Was agreed it didn't make sense to let the user "back" into a closed grant to be redirected to the same page. Also didn't work.

Ticket # and link

GAP:2360

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).

