### PR TITLE
Replacing next transforms with SWC over babel

### DIFF
--- a/packages/admin/next.config.js
+++ b/packages/admin/next.config.js
@@ -31,4 +31,7 @@ module.exports = {
     TECHNICAL_SUPPORT_DOMAIN: process.env.TECHNICAL_SUPPORT_DOMAIN,
     SUPER_ADMIN_DASHBOARD_URL: process.env.SUPER_ADMIN_DASHBOARD_URL,
   },
+  experimental: {
+    forceSwcTransforms: true,
+  },
 };

--- a/packages/applicant/next.config.js
+++ b/packages/applicant/next.config.js
@@ -34,4 +34,7 @@ module.exports = {
     }';`,
   },
   basePath: process.env.SUB_PATH || '/apply/applicant',
+  experimental: {
+    forceSwcTransforms: true,
+  },
 };


### PR DESCRIPTION
Removing the "swc-disabled" message as per docs https://nextjs.org/docs/messages/swc-disabled

I was unable to remove babel entirely as jest is extremely difficult to configure due to the monorepo nature of our apps. However this change should give us most of the benefits of SWC being:

> This new compiler is up to 17x faster than Babel when compiling individual files and up to 5x faster Fast Refresh.