### PR TITLE
GAP-2973: word count validation

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.page.tsx
@@ -32,6 +32,11 @@ type RequestBody = {
   _csrf?: string;
 };
 
+const WORD_LIMIT_MAP = {
+  [ResponseType.ShortAnswer]: 300,
+  [ResponseType.LongAnswer]: 5000,
+};
+
 export const getServerSideProps: GetServerSideProps = async ({
   params,
   req,
@@ -67,11 +72,16 @@ export const getServerSideProps: GetServerSideProps = async ({
           sessionCookie
         )) as QuestionSummary;
         const { optional, ...restOfQuestionSummary } = questionSummary;
+        const maxWords =
+          WORD_LIMIT_MAP[body.responseType as keyof typeof WORD_LIMIT_MAP];
 
         await postQuestion(sessionId, applicationId, sectionId, {
           ...restOfQuestionSummary,
           ...props,
-          validation: { mandatory: optional !== 'true' },
+          validation: {
+            maxWords,
+            mandatory: optional !== 'true',
+          },
         });
 
         return {
@@ -194,7 +204,7 @@ const QuestionType = ({
                 label: ResponseTypeLabels[ResponseType.ShortAnswer],
                 hint: (
                   <QuestionTypeHint
-                    description="Can have a maximum of 250 characters entered."
+                    description="Can have a maximum of 300 words entered."
                     questionType="short-answer"
                     imageFileName="text-input"
                     imageAlt="A screenshot of a text input, with a title and description"
@@ -206,7 +216,7 @@ const QuestionType = ({
                 label: ResponseTypeLabels[ResponseType.LongAnswer],
                 hint: (
                   <QuestionTypeHint
-                    description="Can have a maximum of 6000 characters entered."
+                    description="Can have a maximum of 5000 words entered."
                     questionType="long-answer"
                     imageFileName="text-area"
                     imageAlt="A screenshot of a long text area input, along with a title and description"

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type.test.tsx
@@ -77,13 +77,13 @@ describe('Question type', () => {
     it('Should have a short answer', () => {
       render(component);
       screen.getByRole('radio', { name: 'Short answer' });
-      screen.getByText('Can have a maximum of 250 characters entered.');
+      screen.getByText('Can have a maximum of 300 words entered.');
     });
 
     it('Should have a long answer', () => {
       render(component);
       screen.getByRole('radio', { name: 'Long answer' });
-      screen.getByText('Can have a maximum of 6000 characters entered.');
+      screen.getByText('Can have a maximum of 5000 words entered.');
     });
 
     it('Should have a radio answer', () => {

--- a/packages/admin/src/services/QuestionService.ts
+++ b/packages/admin/src/services/QuestionService.ts
@@ -39,7 +39,7 @@ const postQuestion = (
     hintText?: string;
     displayText?: string;
     questionSuffix?: string;
-    validation: { mandatory: boolean };
+    validation: { maxWords: number; mandatory: boolean };
     options?: string[];
   }
 ): Promise<void> => {

--- a/packages/admin/src/services/QuestionService.ts
+++ b/packages/admin/src/services/QuestionService.ts
@@ -39,7 +39,7 @@ const postQuestion = (
     hintText?: string;
     displayText?: string;
     questionSuffix?: string;
-    validation: { maxWords: number; mandatory: boolean };
+    validation: { maxWords?: number; mandatory: boolean };
     options?: string[];
   }
 ): Promise<void> => {

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.page.tsx
@@ -201,8 +201,12 @@ export default function QuestionPage({
       inputType = (
         <TextInput
           {...commonProps}
-          limitWords
-          limit={question.validation.maxWords || undefined}
+          limitWords={Boolean(question.validation.maxWords)}
+          limit={
+            question.validation.maxWords ||
+            question.validation.maxLength ||
+            undefined
+          }
           defaultValue={
             error ? temporaryErrorInputValue[0] : response || undefined
           }
@@ -225,8 +229,12 @@ export default function QuestionPage({
       inputType = (
         <TextArea
           {...commonProps}
-          limitWords
-          limit={question.validation.maxWords || undefined}
+          limitWords={Boolean(question.validation.maxWords)}
+          limit={
+            question.validation.maxWords ||
+            question.validation.maxLength ||
+            undefined
+          }
           defaultValue={
             error ? temporaryErrorInputValue[0] : response || undefined
           }

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.page.tsx
@@ -201,7 +201,8 @@ export default function QuestionPage({
       inputType = (
         <TextInput
           {...commonProps}
-          limit={question.validation.maxLength || undefined}
+          limitWords
+          limit={question.validation.maxWords || undefined}
           defaultValue={
             error ? temporaryErrorInputValue[0] : response || undefined
           }
@@ -224,7 +225,8 @@ export default function QuestionPage({
       inputType = (
         <TextArea
           {...commonProps}
-          limit={question.validation.maxLength || undefined}
+          limitWords
+          limit={question.validation.maxWords || undefined}
           defaultValue={
             error ? temporaryErrorInputValue[0] : response || undefined
           }

--- a/packages/gap-web-ui/src/components/question-page/inputs/TextArea.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/TextArea.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ErrorMessage from '../../display-errors/ErrorMessage';
 import Details from '../Details';
 import { InputComponentProps } from './InputComponentProps';
+import { HARD_CHAR_LIMIT } from './constants';
 
 const TextArea = ({
   questionTitle,
@@ -88,9 +89,10 @@ const TextArea = ({
           className="govuk-hint govuk-character-count__message"
           data-testid="character-limit-div"
         >
-          {/* Written as full sentences for accessibility */}
           {limitWords
-            ? `You can enter up to ${limit} words`
+            ? `You can enter up to ${limit} ${
+                limit > HARD_CHAR_LIMIT ? 'characters' : 'words'
+              }`
             : `You can enter up to ${limit} characters`}
         </div>
       )}

--- a/packages/gap-web-ui/src/components/question-page/inputs/TextInput.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/TextInput.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import { TextInputSubtype } from '../../../types/InputType';
 import ErrorMessage from '../../display-errors/ErrorMessage';
 import { InputComponentProps } from './InputComponentProps';
+import { HARD_CHAR_LIMIT } from './constants';
 
 const TextInput = ({
   children,
@@ -22,6 +23,7 @@ const TextInput = ({
   fieldPrefix = '£',
   multipleQuestionPage = true,
   limit,
+  limitWords = false,
 }: TextInputComponentProps) => {
   const ariaDescribedByText: string = fieldName + '-hint';
   const hasError = fieldErrors.some((fieldError) =>
@@ -102,7 +104,8 @@ const TextInput = ({
     <div
       className="govuk-character-count"
       data-module="govuk-character-count"
-      data-maxlength={limit}
+      data-maxlength={!limitWords ? limit : undefined}
+      data-maxwords={limitWords ? limit : undefined}
     >
       <div
         className={`govuk-form-group${
@@ -152,7 +155,11 @@ const TextInput = ({
             className="govuk-hint govuk-character-count__message"
             data-testid="character-limit-div"
           >
-            You can enter up to {limit} characters
+            {limitWords
+              ? `You can enter up to ${limit} ${
+                  limit > HARD_CHAR_LIMIT ? 'characters' : 'words'
+                }`
+              : `You can enter up to ${limit} characters`}
           </div>
         )}
         {children}
@@ -172,6 +179,7 @@ export interface TextInputComponentProps extends InputComponentProps {
   newLineAccepted?: boolean;
   fieldPrefix?: string | null;
   limit?: number;
+  limitWords?: boolean;
 }
 
 export default TextInput;

--- a/packages/gap-web-ui/src/components/question-page/inputs/constants/index.ts
+++ b/packages/gap-web-ui/src/components/question-page/inputs/constants/index.ts
@@ -1,0 +1,1 @@
+export const HARD_CHAR_LIMIT = 40000;


### PR DESCRIPTION
## Description

Ticket # and link

adds default word count validation to text / textarea questions 

https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2397

Related pr: https://github.com/cabinetoffice/gap-find-admin-backend/pull/169


## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
