### PR TITLE
GAP-2102: Retain scroll position after moving sections

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/components/Sections.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/components/Sections.tsx
@@ -14,6 +14,8 @@ interface SectionsProps {
   applicationStatus: ApplicationFormSummary['applicationStatus'];
   formAction: string;
   csrfToken: string;
+  formRef: React.RefObject<HTMLFormElement>;
+  setNewScrollPosition: (scrollPosition: number) => void;
 }
 
 const CUSTOM_SECTION_FIRST_INDEX = 2;
@@ -24,6 +26,8 @@ const Sections = ({
   applicationStatus,
   formAction,
   csrfToken,
+  formRef,
+  setNewScrollPosition,
 }: SectionsProps) => {
   return (
     <FlexibleQuestionPageLayout
@@ -31,6 +35,7 @@ const Sections = ({
       fieldErrors={[]}
       csrfToken={csrfToken}
       fullPageWidth={true}
+      formRef={formRef}
     >
       {sections.map((section, sectionIndex) => {
         const isSectionEligibilityOrEssential =
@@ -60,6 +65,10 @@ const Sections = ({
                           data-cy="cyUpButton"
                           name={`Up/${section.sectionId}`}
                           disabled={sectionIndex === CUSTOM_SECTION_FIRST_INDEX}
+                          onClick={() => {
+                            setNewScrollPosition(window.scrollY);
+                            formRef?.current?.submit();
+                          }}
                         >
                           Up
                         </button>
@@ -69,6 +78,10 @@ const Sections = ({
                           data-cy="cyDownButton"
                           name={`Down/${section.sectionId}`}
                           disabled={sectionIndex === sections.length - 1}
+                          onClick={() => {
+                            setNewScrollPosition(window.scrollY);
+                            formRef?.current?.submit();
+                          }}
                         >
                           Down
                         </button>

--- a/packages/admin/src/pages/build-application/[applicationId]/components/Sections.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/components/Sections.tsx
@@ -12,7 +12,7 @@ interface SectionsProps {
   sections: ApplicationFormSection[];
   applicationId: string;
   applicationStatus: ApplicationFormSummary['applicationStatus'];
-  resolvedUrl: string;
+  formAction: string;
   csrfToken: string;
 }
 
@@ -22,12 +22,12 @@ const Sections = ({
   sections,
   applicationId,
   applicationStatus,
-  resolvedUrl,
+  formAction,
   csrfToken,
 }: SectionsProps) => {
   return (
     <FlexibleQuestionPageLayout
-      formAction={resolvedUrl}
+      formAction={formAction}
       fieldErrors={[]}
       csrfToken={csrfToken}
       fullPageWidth={true}

--- a/packages/admin/src/pages/build-application/[applicationId]/components/Sections.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/components/Sections.tsx
@@ -29,6 +29,11 @@ const Sections = ({
   formRef,
   setNewScrollPosition,
 }: SectionsProps) => {
+  function handleOnUpDownButtonClick() {
+    setNewScrollPosition(window.scrollY);
+    formRef?.current?.submit();
+  }
+
   return (
     <FlexibleQuestionPageLayout
       formAction={formAction}
@@ -65,10 +70,7 @@ const Sections = ({
                           data-cy="cyUpButton"
                           name={`Up/${section.sectionId}`}
                           disabled={sectionIndex === CUSTOM_SECTION_FIRST_INDEX}
-                          onClick={() => {
-                            setNewScrollPosition(window.scrollY);
-                            formRef?.current?.submit();
-                          }}
+                          onClick={handleOnUpDownButtonClick}
                         >
                           Up
                         </button>
@@ -78,10 +80,7 @@ const Sections = ({
                           data-cy="cyDownButton"
                           name={`Down/${section.sectionId}`}
                           disabled={sectionIndex === sections.length - 1}
-                          onClick={() => {
-                            setNewScrollPosition(window.scrollY);
-                            formRef?.current?.submit();
-                          }}
+                          onClick={handleOnUpDownButtonClick}
                         >
                           Down
                         </button>

--- a/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
@@ -15,7 +15,7 @@ import UnpublishSummary from './components/UnpublishSummary';
 import InferProps from '../../../types/InferProps';
 import callServiceMethod from '../../../utils/callServiceMethod';
 import { generateErrorPageParams } from '../../../utils/serviceErrorHelpers';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 export const getServerSideProps = async ({
   params,
@@ -135,24 +135,12 @@ const Dashboard = ({
     }
   });
 
+  const formRef = useRef<HTMLFormElement>(null);
   const [newScrollPosition, setNewScrollPosition] = useState(
     scrollPosition ?? 0
   );
   const formAction =
     resolvedUrl.split('?')[0] + `?scrollPosition=${newScrollPosition}`;
-
-  function handleScroll() {
-    setNewScrollPosition(window.scrollY);
-  }
-
-  // Repeatedly calculate the scroll position every 10ms - I hope there's a better way
-  useEffect(() => {
-    const interval = setInterval(() => {
-      handleScroll();
-    }, 10);
-
-    return () => clearInterval(interval);
-  }, []);
 
   useEffect(() => {
     setTimeout(() => {
@@ -224,6 +212,8 @@ const Dashboard = ({
           applicationStatus={applicationStatus}
           formAction={formAction}
           csrfToken={csrfToken}
+          setNewScrollPosition={setNewScrollPosition}
+          formRef={formRef}
         />
 
         {applicationStatus === 'PUBLISHED' ? (

--- a/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
@@ -15,6 +15,7 @@ import UnpublishSummary from './components/UnpublishSummary';
 import InferProps from '../../../types/InferProps';
 import callServiceMethod from '../../../utils/callServiceMethod';
 import { generateErrorPageParams } from '../../../utils/serviceErrorHelpers';
+import { useEffect, useState } from 'react';
 
 export const getServerSideProps = async ({
   params,
@@ -24,7 +25,10 @@ export const getServerSideProps = async ({
   resolvedUrl,
 }: GetServerSidePropsContext) => {
   const { applicationId } = params as Record<string, string>;
-  const { recentlyUnpublished } = query;
+  const { recentlyUnpublished, scrollPosition } = query as Record<
+    string,
+    string
+  >;
 
   const result = await callServiceMethod(
     req,
@@ -41,12 +45,16 @@ export const getServerSideProps = async ({
         sessionId
       );
     },
-    `/build-application/${applicationId}/dashboard`,
+    `/build-application/${applicationId}/dashboard?scrollPosition=${scrollPosition}`,
     generateErrorPageParams(
       'Something went wrong while trying to update section orders.',
       `/build-application/${applicationId}/dashboard`
     )
   );
+
+  if ('redirect' in result) {
+    return result;
+  }
 
   let grantScheme;
   let applicationFormSummary;
@@ -96,6 +104,7 @@ export const getServerSideProps = async ({
       applyToApplicationUrl,
       resolvedUrl: process.env.SUB_PATH + resolvedUrl,
       csrfToken: res.getHeader('x-csrf-token') as string,
+      scrollPosition: Number(scrollPosition ?? 0),
     },
   };
 };
@@ -110,6 +119,7 @@ const Dashboard = ({
   applyToApplicationUrl,
   resolvedUrl,
   csrfToken,
+  scrollPosition,
 }: InferProps<typeof getServerSideProps>) => {
   const { publicRuntimeConfig } = getConfig();
   const findAGrantLink = publicRuntimeConfig.FIND_A_GRANT_URL;
@@ -124,6 +134,34 @@ const Dashboard = ({
       return section.questions ? section.questions.length < 1 : true;
     }
   });
+
+  const [newScrollPosition, setNewScrollPosition] = useState(
+    scrollPosition ?? 0
+  );
+  const formAction =
+    resolvedUrl.split('?')[0] + `?scrollPosition=${newScrollPosition}`;
+
+  function handleScroll() {
+    setNewScrollPosition(window.scrollY);
+  }
+
+  // Repeatedly calculate the scroll position every 10ms - I hope there's a better way
+  useEffect(() => {
+    const interval = setInterval(() => {
+      handleScroll();
+    }, 10);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    setTimeout(() => {
+      window.scrollTo({
+        top: scrollPosition,
+        behavior: 'instant' as ScrollBehavior,
+      });
+    }, 10);
+  }, []);
 
   return (
     <>
@@ -184,7 +222,7 @@ const Dashboard = ({
           sections={sections}
           applicationId={applicationId}
           applicationStatus={applicationStatus}
-          resolvedUrl={resolvedUrl}
+          formAction={formAction}
           csrfToken={csrfToken}
         />
 

--- a/packages/gap-web-ui/src/components/question-page/FlexibleQuestionPageLayout.tsx
+++ b/packages/gap-web-ui/src/components/question-page/FlexibleQuestionPageLayout.tsx
@@ -11,6 +11,7 @@ const FlexibleQuestionPageLayout = ({
   encType = 'application/x-www-form-urlencoded',
   sideBarContent,
   fullPageWidth,
+  formRef,
 }: FlexibleQuestionPageProps) => {
   if (typeof window !== 'undefined') {
     const errorSummary = window.document.getElementById('error-summary');
@@ -38,6 +39,7 @@ const FlexibleQuestionPageLayout = ({
             data-testid="question-page-form"
             id="form-main-content"
             encType={encType}
+            ref={formRef}
           >
             {pageCaption && (
               <span
@@ -72,6 +74,7 @@ export interface FlexibleQuestionPageProps {
   encType?: string; //can be optional as forms default to 'application/x-www-form-urlencoded' but needs to be set to 'multipart/form-data' for file uploads
   sideBarContent?: JSX.Element;
   fullPageWidth?: boolean;
+  formRef?: React.RefObject<HTMLFormElement>;
 }
 
 export default FlexibleQuestionPageLayout;


### PR DESCRIPTION
Retains scroll position after shifting sections

This is just an enhancement - still functions without javascript


https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/b0b7f55e-e508-44ee-b0f4-e4a1d1377522

