### PR TITLE
GAP-2410 | Fix flaky E2E tests RE Sign In Details

### DIFF
--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
 import { routes } from '../../utils/routes';
 import { ImportantBanner } from 'gap-web-ui';
 import Link from 'next/link';
+import styles from '../../components/card/Card.module.scss';
 
 export type ApplicantDashBoardProps = {
   organisationType: string;
@@ -138,11 +139,20 @@ export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
               description="Change the details saved to your profile"
             />
             {oneLoginEnabled && (
-              <Card
-                link={routes.signInDetails}
-                linkDescription={'Your sign in details'}
-                description={'Change your sign in details'}
-              />
+              <div className="govuk-grid-column-one-half ">
+                <div className={styles.card}>
+                  <h3 className="govuk-heading-s">
+                    <a
+                      href={'/apply/applicant/sign-in-details'}
+                      data-cy={`cy-link-card-Your sign in details`}
+                      className="govuk-link govuk-link--no-visited-state"
+                    >
+                      {'Your sign in details'}
+                    </a>
+                  </h3>
+                  <p className="govuk-body">{'Change your sign in details'}</p>
+                </div>
+              </div>
             )}
           </div>
         </section>

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -143,8 +143,8 @@ export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
                 <div className={styles.card}>
                   <h3 className="govuk-heading-s">
                     <a
-                      href={'/apply/applicant/sign-in-details'}
-                      data-cy={`cy-link-card-Your sign in details`}
+                      href="/apply/applicant/sign-in-details"
+                      data-cy="cy-link-card-Your sign in details"
                       className="govuk-link govuk-link--no-visited-state"
                     >
                       Your sign in details

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -150,7 +150,7 @@ export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
                       {'Your sign in details'}
                     </a>
                   </h3>
-                  <p className="govuk-body">{'Change your sign in details'}</p>
+                  <p className="govuk-body">Change your sign in details</p>
                 </div>
               </div>
             )}

--- a/packages/applicant/src/pages/dashboard/Dashboard.tsx
+++ b/packages/applicant/src/pages/dashboard/Dashboard.tsx
@@ -147,7 +147,7 @@ export const ApplicantDashboard: FC<ApplicantDashBoardProps> = ({
                       data-cy={`cy-link-card-Your sign in details`}
                       className="govuk-link govuk-link--no-visited-state"
                     >
-                      {'Your sign in details'}
+                      Your sign in details
                     </a>
                   </h3>
                   <p className="govuk-body">Change your sign in details</p>


### PR DESCRIPTION
changing from Link to anchor tag should prevent next from prefetching this page, which means that Cypress will not attempt to open it and thus won't be "logged out"

## Description

[GAP-2410](https://technologyprogramme.atlassian.net/browse/GAP-2410)

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2410]: https://technologyprogramme.atlassian.net/browse/GAP-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ