### PR TITLE
TMI2-622 - Adding feedback survey to scheduled adverts

### DIFF
--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/schedule-success.page.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/schedule-success.page.tsx
@@ -6,11 +6,11 @@ import InferProps from '../../../../../types/InferProps';
 export const getServerSideProps = async ({
   params,
 }: GetServerSidePropsContext) => {
-  const { schemeId } = params as Record<string, string>;
+  const { schemeId, advertId } = params as Record<string, string>;
 
   return {
     props: {
-      backToAccountLink: `/scheme/${schemeId}`,
+      backToAccountLink: `/scheme/${schemeId}/advert/${advertId}/survey`,
     },
   };
 };

--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/schedule-success.test.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/schedule-success.test.tsx
@@ -13,7 +13,7 @@ import {
 import InferProps from '../../../../../types/InferProps';
 
 const getDefaultProps = (): InferProps<typeof getServerSideProps> => ({
-  backToAccountLink: `/scheme/schemeId`,
+  backToAccountLink: `/scheme/schemeId/advert/advertId/survey`,
 });
 
 describe('Advert - Schedule Success Page', () => {
@@ -28,7 +28,7 @@ describe('Advert - Schedule Success Page', () => {
     it('Should return the link to advert as a prop when slug is provided', async () => {
       const result = await getServerSideProps(getContext(getDefaultContext));
       expectObjectEquals(result, {
-        props: { backToAccountLink: '/scheme/schemeId' },
+        props: { backToAccountLink: `/scheme/schemeId/advert/advertId/survey` },
       });
     });
   });
@@ -41,7 +41,10 @@ describe('Advert - Schedule Success Page', () => {
     it("Should render 'Back to my account' button", () => {
       expect(
         screen.getByRole('button', { name: 'Back to my account' })
-      ).toHaveAttribute('href', '/apply/scheme/schemeId');
+      ).toHaveAttribute(
+        'href',
+        '/apply/scheme/schemeId/advert/advertId/survey'
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/TMI2-622

Admin feedback survey was only being showed after an immediately published advert or application form.

This change redirects admins to the survey page once they've successfully scheduled an advert.

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
