### PR TITLE
TMI2-596: disable publish button onClick

### DIFF
--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/components/PublishOrScheduleButton.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/components/PublishOrScheduleButton.tsx
@@ -1,4 +1,5 @@
 import { Button, FlexibleQuestionPageLayout } from 'gap-web-ui';
+import { useRef, useState } from 'react';
 import CustomLink from '../../../../../../../components/custom-link/CustomLink';
 
 type PublishOrScheduleButtonProps = {
@@ -18,11 +19,20 @@ const PublishOrScheduleButton = ({
   advertId,
   advertName,
 }: PublishOrScheduleButtonProps) => {
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleSubmit = () => {
+    if (formRef.current) {
+      formRef.current.submit();
+    }
+  };
   return (
     <FlexibleQuestionPageLayout
       formAction={resolvedUrl}
       fieldErrors={[]}
       csrfToken={csrfToken}
+      formRef={formRef}
     >
       {futurePublishingDate ? (
         <div
@@ -54,6 +64,11 @@ const PublishOrScheduleButton = ({
               : `Publish my advert - ${advertName}`
           }
           data-cy="cy-advert-confirm-and-publish"
+          disabled={isButtonDisabled}
+          onClick={() => {
+            setIsButtonDisabled(true);
+            handleSubmit();
+          }}
         />
 
         <CustomLink

--- a/packages/gap-web-ui/src/components/question-page/FlexibleQuestionPageLayout.tsx
+++ b/packages/gap-web-ui/src/components/question-page/FlexibleQuestionPageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, RefObject } from 'react';
 import { ValidationError } from '../../types/ValidationErrorType';
 import ErrorBanner from '../display-errors/ErrorBanner';
 
@@ -74,7 +74,7 @@ export interface FlexibleQuestionPageProps {
   encType?: string; //can be optional as forms default to 'application/x-www-form-urlencoded' but needs to be set to 'multipart/form-data' for file uploads
   sideBarContent?: JSX.Element;
   fullPageWidth?: boolean;
-  formRef?: React.RefObject<HTMLFormElement>;
+  formRef?: RefObject<HTMLFormElement>;
 }
 
 export default FlexibleQuestionPageLayout;

--- a/packages/gap-web-ui/src/components/question-page/inputs/Button.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/Button.tsx
@@ -16,6 +16,7 @@ export interface ButtonProps {
   ariaLabel?: string;
   tabIndex?: number;
   hidden?: boolean;
+  onClick?: () => void;
 }
 
 const Button: FC<ButtonProps> = ({
@@ -26,6 +27,7 @@ const Button: FC<ButtonProps> = ({
   addNameAttribute = false,
   disabled = false,
   ariaLabel,
+  onClick,
   ...additionalProps
 }) => {
   return (
@@ -43,6 +45,7 @@ const Button: FC<ButtonProps> = ({
       aria-label={ariaLabel}
       aria-disabled={disabled}
       disabled={disabled}
+      onClick={onClick}
     >
       {text}
     </button>


### PR DESCRIPTION
## Description
When the publish button is clicked, it is disabled and the form is submitted so that the user cannot click the button multiple times. This will not work with javascript

Ticket # and link
TMI2-596: https://technologyprogramme.atlassian.net/browse/TMI2-596

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
