### PR TITLE
GAP-2049: Conditionally redirect to summary page after file upload 

### DIFF
--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.page.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.page.tsx
@@ -13,6 +13,8 @@ const handler = async (req, res) => {
   const isFromCYAPage =
     referer.includes('fromCYAPage=true') || req.query?.fromCYAPage;
 
+  const isFromSummaryPage = referer.includes('fromSubmissionSummaryPage=true');
+
   await deleteAttachmentByQuestionId(
     submissionId,
     sectionId,
@@ -27,8 +29,14 @@ const handler = async (req, res) => {
       submissionId,
       sectionId,
       questionId
-    )}${isFromCYAPage ? '?fromCYAPage=true' : ''}`
+    )}${getQueryString(isFromCYAPage, isFromSummaryPage)}`
   );
 };
+
+function getQueryString(isFromCYAPage: boolean, isFromSummaryPage: boolean) {
+  if (isFromCYAPage) return '?fromCYAPage=true';
+  if (isFromSummaryPage) return '?fromSubmissionSummaryPage=true';
+  return '';
+}
 
 export default handler;

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
@@ -1,0 +1,66 @@
+import handler from './remove.page'; // Update the path accordingly
+import { routes } from '../../../../../../../../../../../utils/routes';
+import { deleteAttachmentByQuestionId } from '../../../../../../../../../../../services/SubmissionService';
+
+jest.mock('../../../../../../../../../../../services/SubmissionService');
+jest.mock('../../../../../../../../../../../utils/jwt', () => ({
+  getJwtFromCookies: () => 'jwt',
+}));
+
+describe('handler', () => {
+  const testCases = [
+    {
+      description: 'without query string',
+      query: {},
+      expectedQueryString: '',
+    },
+    {
+      description: 'with fromCYAPage query string',
+      query: { fromCYAPage: true },
+      expectedQueryString: '?fromCYAPage=true',
+    },
+    {
+      description: 'with fromSubmissionSummaryPage query string',
+      query: { fromSubmissionSummaryPage: true },
+      expectedQueryString: '?fromSubmissionSummaryPage=true',
+    },
+  ];
+
+  test.each(testCases)(
+    'should call deleteAttachmentByQuestionId and redirect %s',
+    async ({ query, expectedQueryString }) => {
+      const req = {
+        query: {
+          submissionId: 'submissionId',
+          sectionId: 'sectionId',
+          questionId: 'questionId',
+          attachmentId: 'attachmentId',
+          ...query,
+        },
+        headers: {
+          referer: 'http://localhost:3000' + expectedQueryString,
+        },
+      };
+      const res = {
+        redirect: jest.fn(),
+      };
+      await handler(req, res);
+
+      expect(deleteAttachmentByQuestionId).toHaveBeenCalledWith(
+        'submissionId',
+        'sectionId',
+        'questionId',
+        'attachmentId',
+        'jwt'
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        302,
+        `${process.env.HOST}${routes.submissions.question(
+          'submissionId',
+          'sectionId',
+          'questionId'
+        )}${expectedQueryString}`
+      );
+    }
+  );
+});

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
@@ -26,7 +26,7 @@ describe('handler', () => {
     },
   ];
 
-  test.each(testCases)(
+  it.each(testCases)(
     'should call deleteAttachmentByQuestionId and redirect $description',
     async ({ query, expectedQueryString }) => {
       const req = {

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
@@ -27,7 +27,7 @@ describe('handler', () => {
   ];
 
   test.each(testCases)(
-    'should call deleteAttachmentByQuestionId and redirect %s',
+    'should call deleteAttachmentByQuestionId and redirect $description',
     async ({ query, expectedQueryString }) => {
       const req = {
         query: {

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/attachments/[attachmentId]/remove.test.tsx
@@ -1,4 +1,4 @@
-import handler from './remove.page'; // Update the path accordingly
+import handler from './remove.page';
 import { routes } from '../../../../../../../../../../../utils/routes';
 import { deleteAttachmentByQuestionId } from '../../../../../../../../../../../services/SubmissionService';
 

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.page.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.page.tsx
@@ -214,7 +214,7 @@ type GetRedirectUrlParams = {
   sectionId: string;
 };
 
-function getRedirectUrl({
+export function getRedirectUrl({
   isFromCYAPage,
   isFromSummaryPage,
   nextNavParams,

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.test.tsx
@@ -1,0 +1,66 @@
+import handler, { getRedirectUrl } from './upload-file.page';
+import { routes } from '../../../../../../../../../utils/routes';
+import { NextNavigation } from '../../../../../../../../../services/SubmissionService';
+
+describe('getRedirectUrl()', () => {
+  const testCases = [
+    {
+      description: 'fromCYAPage is true',
+      isFromCYAPage: true,
+      isFromSummaryPage: false,
+      nextNavParams: null,
+      submissionId: 'submissionId',
+      sectionId: 'sectionId',
+      expectedRedirect: routes.submissions.section('submissionId', 'sectionId'),
+    },
+    {
+      description: 'fromSummaryPage is true',
+      isFromCYAPage: false,
+      isFromSummaryPage: true,
+      nextNavParams: null,
+      submissionId: 'submissionId',
+      sectionId: 'sectionId',
+      expectedRedirect: routes.submissions.summary('submissionId'),
+    },
+    {
+      description: 'neither fromCYAPage nor fromSummaryPage is true',
+      isFromCYAPage: false,
+      isFromSummaryPage: false,
+      nextNavParams: {
+        nextNavigation: {
+          sectionList: false,
+          questionId: 'nextQuestionId',
+        },
+      },
+      submissionId: 'submissionId',
+      sectionId: 'sectionId',
+      expectedRedirect: routes.submissions.question(
+        'submissionId',
+        'sectionId',
+        'nextQuestionId'
+      ),
+    },
+  ];
+
+  test.each(testCases)(
+    'should return the correct redirect URL when $description',
+    ({
+      isFromCYAPage,
+      isFromSummaryPage,
+      nextNavParams,
+      submissionId,
+      sectionId,
+      expectedRedirect,
+    }) => {
+      const redirectUrl = getRedirectUrl({
+        isFromCYAPage,
+        isFromSummaryPage,
+        nextNavParams: nextNavParams as NextNavigation,
+        submissionId,
+        sectionId,
+      });
+
+      expect(redirectUrl).toBe(expectedRedirect);
+    }
+  );
+});

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.test.tsx
@@ -42,7 +42,7 @@ describe('getRedirectUrl()', () => {
     },
   ];
 
-  test.each(testCases)(
+  it.each(testCases)(
     'should return the correct redirect URL when $description',
     ({
       isFromCYAPage,

--- a/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.test.tsx
+++ b/packages/applicant/src/pages/api/routes/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/upload-file.test.tsx
@@ -1,4 +1,4 @@
-import handler, { getRedirectUrl } from './upload-file.page';
+import { getRedirectUrl } from './upload-file.page';
 import { routes } from '../../../../../../../../../utils/routes';
 import { NextNavigation } from '../../../../../../../../../services/SubmissionService';
 

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.page.tsx
@@ -196,6 +196,11 @@ export default function QuestionPage({
     fieldErrors: error || [],
     titleSize: titleSizeType,
   };
+
+  const fromSubmissionSummaryPage =
+    new URLSearchParams(queryParams).get('fromSubmissionSummaryPage') ===
+    'true';
+
   switch (responseType) {
     case 'ShortAnswer':
       inputType = (
@@ -346,26 +351,30 @@ export default function QuestionPage({
                   grantSubmissionId,
                   sectionId,
                   questionId
-                )}/attachments/${attachmentId}/remove${
-                  isRefererCheckYourAnswerScreen ? '?fromCYAPage=true' : ''
-                }`
+                )}/attachments/${attachmentId}/remove${getFileQueryString()}`
               : undefined
           }
         />
       );
+
       encType = 'multipart/form-data';
       formAction =
         publicRuntimeConfig.subPath +
         '/api/routes' +
         routes.submissions.question(grantSubmissionId, sectionId, questionId) +
-        '/upload-file';
+        '/upload-file' +
+        getFileQueryString();
       break;
   }
 
+  function getFileQueryString() {
+    if (isRefererCheckYourAnswerScreen) return '?fromCYAPage=true';
+    if (fromSubmissionSummaryPage) return '?fromSubmissionSummaryPage=true';
+    return '';
+  }
+
   let backLinkUrl = routes.submissions.sections(grantSubmissionId);
-  const fromSubmissionSummaryPage =
-    new URLSearchParams(queryParams).get('fromSubmissionSummaryPage') ===
-    'true';
+
   if (isRefererCheckYourAnswerScreen) {
     backLinkUrl = routes.submissions.section(grantSubmissionId, sectionId);
   } else if (fromSubmissionSummaryPage) {

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/questions/[questionId]/index.test.tsx
@@ -18,6 +18,7 @@ import QuestionPage, {
   getServerSideProps,
   getValidationErrorsFromQuery,
 } from './index.page';
+import { encode } from 'querystring';
 
 jest.mock('../../../../../../../services/SubmissionService');
 jest.mock('../../../../../../../utils/postQuestion');
@@ -1249,6 +1250,39 @@ describe('QuestionPage', () => {
       expect(form).toHaveAttribute(
         'action',
         '/api/routes/submissions/333333333/sections/ESSENTIAL/questions/UPLOAD/upload-file'
+      );
+      expect(form).toHaveAttribute('encType', 'multipart/form-data');
+    });
+
+    test('form should append a redirect to fromSubmissionSummaryPage', () => {
+      uploadProps.question.response = 'test123.zip';
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            pathname: `/submissions/${submissionId}/sections/${sectionId}/questions/${questionId}`,
+          })}
+        >
+          <QuestionPage
+            questionData={uploadProps}
+            grantName="Test Grant Application"
+            csrfToken="testCSRFToken"
+            isRefererCheckYourAnswerScreen={false}
+            queryParams={encode({ fromSubmissionSummaryPage: 'true' })}
+          />
+        </RouterContext.Provider>
+      );
+      screen.getByText(/uploaded file/i);
+      const removeButton = screen.getByRole('link', {
+        name: 'Remove File test123.zip',
+      });
+      const form = screen.getByTestId('question-page-form');
+      expect(removeButton).toHaveAttribute(
+        'href',
+        '/api/routes/submissions/333333333/sections/ESSENTIAL/questions/UPLOAD/attachments/attachmentId/remove?fromSubmissionSummaryPage=true'
+      );
+      expect(form).toHaveAttribute(
+        'action',
+        '/api/routes/submissions/333333333/sections/ESSENTIAL/questions/UPLOAD/upload-file?fromSubmissionSummaryPage=true'
       );
       expect(form).toHaveAttribute('encType', 'multipart/form-data');
     });


### PR DESCRIPTION
## Description

Ticket # and link

Adds logic to redirect an applicant back to the summary page after visiting from there

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
