### PR TITLE
Fix edit question optional default values

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/edit/question-content/index.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/edit/question-content/index.page.tsx
@@ -27,10 +27,12 @@ const QuestionContent = ({
   previousValues,
 }: InferProps<typeof getServerSideProps>) => {
   const optionalRadioDefault = () => {
-    if (previousValues?.optional) return previousValues?.optional;
-    if (questionData.validation.mandatory !== undefined) {
-      return questionData.validation.mandatory === 'false' ? 'Yes' : 'No';
-    }
+    if (previousValues?.optional)
+      return previousValues?.optional === 'true' ? 'Yes' : 'No';
+    if (questionData.validation.mandatory !== undefined)
+      return Boolean(questionData.validation.mandatory) === false
+        ? 'Yes'
+        : 'No';
     return undefined;
   };
 

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/edit/question-content/index.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/edit/question-content/index.test.tsx
@@ -80,7 +80,7 @@ describe('Question content page', () => {
       render(
         <QuestionContent
           {...getPageProps(getDefaultProps, {
-            previousValues: { optional: 'Yes' },
+            previousValues: { optional: 'true' },
             pageData: {
               questionData: {
                 ...getDefaultProps().pageData.questionData,


### PR DESCRIPTION
Regression with editing question optionals default values. This PR fixes the default value.
Tested applying for the application in the recording and optional questions worked as expected


https://github.com/cabinetoffice/gap-find-apply-web/assets/101722961/06b74f86-64de-430e-9ac3-107616721208

