### PR TITLE
fix: remove undesired textinput wrapping

### DIFF
--- a/packages/gap-web-ui/src/components/question-page/inputs/TextInput.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/TextInput.tsx
@@ -54,6 +54,7 @@ const TextInput = ({
   const hasError = fieldErrors.some((fieldError) =>
     fieldError.fieldName.startsWith(fieldName)
   );
+  const shouldRenderInputWithWrapper = !!fieldPrefix || !!fieldSuffix;
   const requiredProps = {
     id: fieldName,
     className: `govuk-input govuk-js-character-count${
@@ -204,7 +205,11 @@ const TextInput = ({
         )}
         <ErrorMessage fieldErrors={fieldErrors} fieldName={fieldName} />
 
-        {limit ? <InputComponent /> : <InputWithWrapperComponent />}
+        {shouldRenderInputWithWrapper ? (
+          <InputWithWrapperComponent />
+        ) : (
+          <InputComponent />
+        )}
         {children}
       </div>
 


### PR DESCRIPTION
## Description

Following change:

![image](https://github.com/cabinetoffice/gap-find-apply-web/assets/135321532/e38aa0d7-29c2-4a48-bf89-ab4f209293f0)

QA (pre-regression):

![image](https://github.com/cabinetoffice/gap-find-apply-web/assets/135321532/d4b1f653-5c5f-41ac-a29b-1dc3abc69f5e)

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
