### PR TITLE
fix word count not saving with short question

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type/index.getServerSideProps.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/question-type/index.getServerSideProps.tsx
@@ -23,6 +23,8 @@ type RequestBody = {
   _csrf?: string;
 };
 
+const SHORT_QUESTION_WORD_LIMIT = 300;
+
 const redirectQuestionType = [
   ResponseType.Dropdown,
   ResponseType.MultipleSelection,
@@ -132,12 +134,16 @@ export const getServerSideProps = async (
         sessionId,
       };
     } else {
+      const maxWords =
+        body.responseType === ResponseType.ShortAnswer
+          ? SHORT_QUESTION_WORD_LIMIT
+          : undefined;
       await postQuestion(sessionId, applicationId, sectionId, {
         ...restOfQuestionSummary,
         ...props,
         validation: {
           mandatory: optional !== 'true',
-          maxWords: '',
+          maxWords,
         },
       });
 


### PR DESCRIPTION
## Description

Fixes word count not saving when selecting a short text question type, resulting in the applicant frontend falling back to a character count when rendering the question.

![image](https://github.com/cabinetoffice/gap-find-apply-web/assets/135321532/789befb2-9363-4324-847d-835bafd08495)

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
