### PR TITLE
TMI2-697: handle draft applciation form

### DIFF
--- a/packages/applicant/src/pages/api/create-submission.page.tsx
+++ b/packages/applicant/src/pages/api/create-submission.page.tsx
@@ -1,16 +1,16 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { GrantApplicantOrganisationProfile } from '../../types/models/GrantApplicantOrganisationProfile';
 import { GrantApplicantOrganisationProfileService } from '../../services/GrantApplicantOrganisationProfileService';
 import { GrantApplicantService } from '../../services/GrantApplicantService';
 import {
   GrantMandatoryQuestionDto,
   GrantMandatoryQuestionService,
 } from '../../services/GrantMandatoryQuestionService';
+import { GrantSchemeService } from '../../services/GrantSchemeService';
 import { createSubmission } from '../../services/SubmissionService';
+import { GrantApplicantOrganisationProfile } from '../../types/models/GrantApplicantOrganisationProfile';
+import { APIGlobalHandler } from '../../utils/apiErrorHandler';
 import { getJwtFromCookies } from '../../utils/jwt';
 import { routes } from '../../utils/routes';
-import { GrantSchemeService } from '../../services/GrantSchemeService';
-import { APIGlobalHandler } from '../../utils/apiErrorHandler';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const grantMandatoryQuestionService =
@@ -43,7 +43,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       jwt
     );
 
-    if (!grantApplication.id) {
+    if (
+      !grantApplication.id ||
+      grantApplication.applicationStatus != 'PUBLISHED'
+    ) {
       await grantMandatoryQuestionService.updateMandatoryQuestion(
         jwt,
         mandatoryQuestionId,

--- a/packages/applicant/src/pages/api/create-submission.test.tsx
+++ b/packages/applicant/src/pages/api/create-submission.test.tsx
@@ -1,6 +1,5 @@
 import { merge } from 'lodash';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { GrantApplicant } from '../../types/models/GrantApplicant';
 import {
   GrantApplicantOrganisationProfileService,
   UpdateOrganisationDetailsDto,
@@ -10,16 +9,18 @@ import {
   GrantMandatoryQuestionDto,
   GrantMandatoryQuestionService,
 } from '../../services/GrantMandatoryQuestionService';
+import { GrantSchemeService } from '../../services/GrantSchemeService';
 import {
   CreateSubmissionResponse,
   createSubmission,
 } from '../../services/SubmissionService';
 import { Overrides } from '../../testUtils/unitTestHelpers';
+import { GrantAdvert } from '../../types/models/GrantAdvert';
+import { GrantApplicant } from '../../types/models/GrantApplicant';
+import { GrantApplication } from '../../types/models/GrantApplication';
 import { getJwtFromCookies } from '../../utils/jwt';
 import { routes } from '../../utils/routes';
 import handler from './create-submission.page';
-import { GrantAdvert } from '../../types/models/GrantAdvert';
-import { GrantSchemeService } from '../../services/GrantSchemeService';
 
 jest.mock('../../services/SubmissionService');
 jest.mock('../../services/GrantMandatoryQuestionService.ts');
@@ -165,10 +166,21 @@ describe('API Handler Tests', () => {
       isInternal: true,
       grantApplicationId: 'grantApplicationId',
     };
+
+    const getGrantApplicationResponse: GrantApplication = {
+      id: '1',
+      version: 2,
+      created: '',
+      lastUpdated: '',
+      lastUpdatedBy: 1,
+      applicationName: 'application name',
+      applicationStatus: 'PUBLISHED',
+      definition: null,
+    };
     GrantSchemeService.getInstance.mockReturnValue({
       getGrantSchemeById: jest.fn().mockResolvedValue({
         grantAdverts: [getAdvertBySchemeIdResponse],
-        grantApplication: { id: '1' },
+        grantApplication: getGrantApplicationResponse,
       }),
     });
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');


### PR DESCRIPTION
## Description
When an advert has an external url with a draft application form, it was trying to send users to this application form. Now a check has been added to send the user to the external application if there is no application form or if the application form has any status other than PUBLISHED

Ticket # and link
TMI2-697: https://technologyprogramme.atlassian.net/browse/TMI2-697

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
