### PR TITLE
TMI2-600: don't show buttons if no submissions to download

### DIFF
--- a/packages/admin/src/pages/scheme/[schemeId]/[exportId]/index.page.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/[exportId]/index.page.tsx
@@ -1,8 +1,10 @@
 import { ImportantBanner, Table } from 'gap-web-ui';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
-import React from 'react';
 
+import { TheadColumn } from 'gap-web-ui/dist/cjs/components/table/Table';
 import CustomLink from '../../../../components/custom-link/CustomLink';
+import Meta from '../../../../components/layout/Meta';
+import { Pagination } from '../../../../components/pagination/Pagination';
 import {
   ExportDetails,
   getExportDetails,
@@ -10,9 +12,6 @@ import {
 import { getGrantScheme } from '../../../../services/SchemeService';
 import { generateErrorPageRedirect } from '../../../../utils/serviceErrorHelpers';
 import { getSessionIdFromCookies } from '../../../../utils/session';
-import { TheadColumn } from 'gap-web-ui/dist/cjs/components/table/Table';
-import { Pagination } from '../../../../components/pagination/Pagination';
-import Meta from '../../../../components/layout/Meta';
 
 export const getServerSideProps = async ({
   req,
@@ -164,26 +163,28 @@ export const CompletedSubmissions = ({
             </b>{' '}
             available to download.
           </p>
-          <div className="govuk-button-group">
-            <CustomLink
-              href={`/apply/admin/api/signed-url?key=${encodeURIComponent(
-                superZipLocation
-              )}`}
-              isButton
-              excludeSubPath
-              disabled={availableSubmissionsTotalCount == 0}
-            >
-              Download all applications
-            </CustomLink>
+          {availableSubmissionsTotalCount > 0 && (
+            <div className="govuk-button-group">
+              <CustomLink
+                href={`/apply/admin/api/signed-url?key=${encodeURIComponent(
+                  superZipLocation
+                )}`}
+                isButton
+                excludeSubPath
+                disabled={availableSubmissionsTotalCount == 0}
+              >
+                Download all applications
+              </CustomLink>
 
-            <CustomLink
-              href={individualApplicationsHref}
-              isSecondaryButton
-              disabled={availableSubmissionsTotalCount == 0}
-            >
-              View individual applications
-            </CustomLink>
-          </div>
+              <CustomLink
+                href={individualApplicationsHref}
+                isSecondaryButton
+                disabled={availableSubmissionsTotalCount == 0}
+              >
+                View individual applications
+              </CustomLink>
+            </div>
+          )}
 
           {unavailableSubmissions.length > 0 && (
             <>

--- a/packages/admin/src/pages/scheme/[schemeId]/[exportId]/index.test.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/[exportId]/index.test.tsx
@@ -184,6 +184,11 @@ describe('Download all submissions page', () => {
         render(unavailableOnlyComponent);
       });
 
+      it('Should not render the two buttons', async () => {
+        expect(screen.queryByText('Download all applications')).toBeFalsy;
+        expect(screen.queryByText('View individual applications')).toBeFalsy();
+      });
+
       it('Renders correct information about submissions', () => {
         screen.getByText('0 applications');
       });
@@ -219,17 +224,6 @@ describe('Download all submissions page', () => {
         screen.getByText(
           'You can view a read-only copy of the applications that are affected in the "Applications unavailable for download" section of this page.'
         );
-      });
-
-      it('Buttons are disabled', () => {
-        const downloadAllLink = screen.getByRole('button', {
-          name: 'Download all applications',
-        });
-        expect(downloadAllLink).toHaveAttribute('disabled');
-        const downloadIndividualLink = screen.getByRole('button', {
-          name: 'View individual applications',
-        });
-        expect(downloadIndividualLink).toHaveAttribute('disabled');
       });
     });
   });


### PR DESCRIPTION
## Description
If there are no submissions available to download then it does not display the download buttons

Ticket # and link
TMI2-600: https://technologyprogramme.atlassian.net/browse/TMI2-600

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
