### PR TITLE
remove 'open in new tab' option for links in rich text editor

### DIFF
--- a/packages/gap-web-ui/src/components/question-page/inputs/RichText.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/RichText.tsx
@@ -87,7 +87,7 @@ const RichText = ({
           toolbar: 'blocks | bold italic | bullist numlist | link',
           block_formats:
             'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
-          target_list: [{ text: 'Current window', value: '' }],
+          link_target_list: false,
         }}
         disabled={disabled}
         value={value}

--- a/packages/gap-web-ui/src/components/question-page/inputs/RichText.tsx
+++ b/packages/gap-web-ui/src/components/question-page/inputs/RichText.tsx
@@ -87,6 +87,7 @@ const RichText = ({
           toolbar: 'blocks | bold italic | bullist numlist | link',
           block_formats:
             'Paragraph=p; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6',
+          target_list: [{ text: 'Current window', value: '' }],
         }}
         disabled={disabled}
         value={value}


### PR DESCRIPTION
## Description

The `target="_blank"` attribute is stripped during the process of retrieving the content from contentful, so we're removing this option as in practical terms it does nothing.

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
