### PR TITLE
GAP-2460 | implement multiple editors error for deleting section

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/delete-confirmation.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/delete-confirmation.page.tsx
@@ -18,9 +18,11 @@ export const getServerSideProps: GetServerSideProps = async ({
   resolvedUrl,
   req,
   res,
+  query,
 }) => {
   const sessionId = getSessionIdFromCookies(req);
   const { applicationId, sectionId } = params as Record<string, string>;
+  const version = query.version as string;
   const errorPageParams = {
     errorInformation: 'Something went wrong while trying to delete a section',
     linkAttributes: {
@@ -38,7 +40,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     async (body: RequestBody) => {
       // if the user has Yes radio selected, run delete service call. else, do nothing
       if (body.deleteBool === 'true') {
-        await deleteSection(sessionId, applicationId, sectionId);
+        await deleteSection(sessionId, applicationId, sectionId, version);
         return true;
       } else if (body.deleteBool === 'false') {
         return false;

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/delete-confirmation.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/delete-confirmation.test.tsx
@@ -15,6 +15,7 @@ jest.mock('../../../../services/ApplicationService');
 
 const APPLICATION_ID = 'testApplicationId';
 const SECTION_ID = 'testSectionId';
+const VERSION = '1';
 
 const customProps = {
   fieldErrors: [],
@@ -40,13 +41,15 @@ const getContext = (overrides: any = {}) =>
         applicationId: APPLICATION_ID,
         sectionId: SECTION_ID,
       } as Record<string, string>,
+      query: {
+        version: VERSION,
+      },
       req: {
         method: 'GET',
         cookies: { 'gap-test': 'testSessionId' },
       },
       res: { getHeader: () => 'testCSRFToken' },
-      resolvedUrl:
-        '/build-application/testApplicationId/testSectionId/delete-confirmation',
+      resolvedUrl: `/build-application/testApplicationId/testSectionId/delete-confirmation?version=${VERSION}`,
     } as unknown as GetServerSidePropsContext,
     overrides
   );
@@ -120,7 +123,7 @@ describe('Delete section page', () => {
 
       expect(value.props.formAction).toStrictEqual(
         process.env.SUB_PATH +
-          `/build-application/${APPLICATION_ID}/${SECTION_ID}/delete-confirmation`
+          `/build-application/${APPLICATION_ID}/${SECTION_ID}/delete-confirmation?version=${VERSION}`
       );
     });
   });

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index.page.tsx
@@ -13,6 +13,7 @@ const EditSectionPage = ({
   section,
   grantApplicationName,
   applicationId,
+  version,
   scrollPosition,
   resolvedUrl,
   csrfToken,
@@ -118,7 +119,7 @@ const EditSectionPage = ({
       </p>
 
       <CustomLink
-        href={`/build-application/${applicationId}/${section.sectionId}/delete-confirmation`}
+        href={`/build-application/${applicationId}/${section.sectionId}/delete-confirmation?version=${version}`}
         isButton
         customStyle="govuk-button--warning"
       >

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
@@ -80,6 +80,7 @@ const getServerSideProps = async ({
 
   return {
     props: {
+      version: applicationFormSummary.audit.version,
       section,
       grantApplicationName: applicationFormSummary.applicationName,
       applicationId: applicationFormSummary.grantApplicationId,

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
@@ -79,6 +79,7 @@ const getDefaultProps = (): InferProps<typeof getServerSideProps> => ({
       },
     ],
   },
+  version: 1,
 });
 
 describe('Edit section page', () => {
@@ -203,6 +204,7 @@ describe('Edit section page', () => {
               sectionTitle: 'some-section-title',
               questions: [],
             },
+            version: 1,
           },
         });
       });
@@ -308,7 +310,7 @@ describe('Edit section page', () => {
       ],
       [
         'Delete section',
-        '/apply/build-application/some-application-id/testSectionId/delete-confirmation',
+        '/apply/build-application/some-application-id/testSectionId/delete-confirmation?version=1',
       ],
       [
         'Save and go back',

--- a/packages/admin/src/services/SectionService.test.ts
+++ b/packages/admin/src/services/SectionService.test.ts
@@ -15,6 +15,7 @@ const BASE_APPLICATION_URL = BACKEND_HOST + '/application-forms';
 const APPLICATION_ID = 'TestApp';
 const SECTION_ID = 'SectionId';
 const SESSION_ID = 'SessionId';
+const VERSION = '1';
 
 describe('SectionService', () => {
   describe('postSection', () => {
@@ -40,10 +41,10 @@ describe('SectionService', () => {
     it('Should delete a section', async () => {
       mockedAxios.delete.mockResolvedValue({});
 
-      await deleteSection(SESSION_ID, APPLICATION_ID, SECTION_ID);
+      await deleteSection(SESSION_ID, APPLICATION_ID, SECTION_ID, VERSION);
 
       expect(mockedAxios.delete).toHaveBeenCalledWith(
-        `${BASE_APPLICATION_URL}/${APPLICATION_ID}/sections/${SECTION_ID}`,
+        `${BASE_APPLICATION_URL}/${APPLICATION_ID}/sections/${SECTION_ID}/${VERSION}`,
         { headers: { Cookie: 'SESSION=SessionId;' }, withCredentials: true }
       );
     });

--- a/packages/admin/src/services/SectionService.ts
+++ b/packages/admin/src/services/SectionService.ts
@@ -26,10 +26,11 @@ const postSection = async (
 const deleteSection = (
   sessionId: string,
   applicationId: string,
-  sectionId: string
+  sectionId: string,
+  version: string
 ): Promise<void> => {
   return axios.delete(
-    `${BASE_APPLICATION_URL}/${applicationId}/sections/${sectionId}`,
+    `${BASE_APPLICATION_URL}/${applicationId}/sections/${sectionId}/${version}`,
     axiosSessionConfig(sessionId)
   );
 };


### PR DESCRIPTION
## Description

[GAP-2460](https://technologyprogramme.atlassian.net/browse/GAP-2460)

Summary of the changes and the related issue. List any dependencies that are required for this change:

Multiple editors - prevent deleting application section if version is outdated
https://github.com/cabinetoffice/gap-find-admin-backend/pull/236

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [x] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
