### PR TITLE
TMI2-702: error assigning department to user

### DIFF
--- a/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.page.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.page.tsx
@@ -1,19 +1,20 @@
 import { SummaryList } from 'gap-web-ui';
-import { getAllDepartments } from '../../../services/SuperAdminService';
-import { getUserTokenFromCookies } from '../../../utils/session';
-import InferProps from '../../../types/InferProps';
-import Meta from '../../../components/layout/Meta';
-import CustomLink from '../../../components/custom-link/CustomLink';
-import { GetServerSidePropsContext } from 'next';
-import { Department } from '../types';
 import { Row } from 'gap-web-ui/dist/cjs/components/summary-list/SummaryList';
-import styles from './manage-departments.module.scss';
+import { GetServerSidePropsContext } from 'next';
+import CustomLink from '../../../components/custom-link/CustomLink';
+import Meta from '../../../components/layout/Meta';
+import { getAllDepartments } from '../../../services/SuperAdminService';
+import InferProps from '../../../types/InferProps';
 import { fetchDataOrGetRedirect } from '../../../utils/fetchDataOrGetRedirect';
+import { getUserTokenFromCookies } from '../../../utils/session';
+import { Department } from '../types';
+import styles from './manage-departments.module.scss';
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const getDepartmentsAndUserId = async (jwt: string) => ({
     departments: await getAllDepartments(jwt),
     userId: context.query?.userId || '',
+    newUserRoles: context.query?.newRoles || '',
   });
 
   const getPageData = () =>
@@ -25,6 +26,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 const ManageDepartmentsPage = ({
   departments,
   userId,
+  newUserRoles,
 }: InferProps<typeof getServerSideProps>) => {
   const rows = departments.map((dept) => getDepartmentRow(dept));
   rows.splice(0, 0, getManageDepartmentsHeadingRow());
@@ -36,7 +38,9 @@ const ManageDepartmentsPage = ({
         isBackButton
         href={
           userId
-            ? `/super-admin-dashboard/user/${userId}/change-department`
+            ? newUserRoles.length > 0
+              ? `/super-admin-dashboard/user/${userId}/change-department?newRoles=${newUserRoles}`
+              : `/super-admin-dashboard/user/${userId}/change-department`
             : '/super-admin-dashboard/'
         }
       />

--- a/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.test.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/manage-departments/index.test.tsx
@@ -15,18 +15,40 @@ const getMockDepartmentData = () => [
   },
 ];
 
+const mockNewUserRoles = ['1', '2', '3'];
+
 describe('Edit department information page', () => {
   test('Should navigate to change user department when provided a userId', async () => {
     render(
-      <ManageDepartmentsPage departments={getMockDepartmentData()} userId="1" />
+      <ManageDepartmentsPage
+        departments={getMockDepartmentData()}
+        userId="1"
+        newUserRoles={[]}
+      />
     );
     expect(screen.getByText('Back').getAttribute('href')).toBe(
       '/apply/super-admin-dashboard/user/1/change-department'
     );
   });
+  test('Should navigate to change user department when provided a userId and newUserRoles', async () => {
+    render(
+      <ManageDepartmentsPage
+        departments={getMockDepartmentData()}
+        userId="1"
+        newUserRoles={mockNewUserRoles}
+      />
+    );
+    expect(screen.getByText('Back').getAttribute('href')).toBe(
+      '/apply/super-admin-dashboard/user/1/change-department?newRoles=1,2,3'
+    );
+  });
   test('Should navigate to dashboard when not provided a userId', async () => {
     render(
-      <ManageDepartmentsPage departments={getMockDepartmentData()} userId="" />
+      <ManageDepartmentsPage
+        departments={getMockDepartmentData()}
+        userId=""
+        newUserRoles={mockNewUserRoles}
+      />
     );
     expect(screen.getByText('Back').getAttribute('href')).toBe(
       '/apply/super-admin-dashboard/'

--- a/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.page.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.page.tsx
@@ -1,15 +1,15 @@
-import { GetServerSidePropsContext } from 'next';
 import { FlexibleQuestionPageLayout, Radio } from 'gap-web-ui';
+import { GetServerSidePropsContext } from 'next';
+import CustomLink from '../../../../components/custom-link/CustomLink';
 import Meta from '../../../../components/layout/Meta';
 import {
   getChangeDepartmentPage,
   updateDepartment,
   updateUserRoles,
 } from '../../../../services/SuperAdminService';
-import { getUserTokenFromCookies } from '../../../../utils/session';
 import InferProps from '../../../../types/InferProps';
-import CustomLink from '../../../../components/custom-link/CustomLink';
 import QuestionPageGetServerSideProps from '../../../../utils/QuestionPageGetServerSideProps';
+import { getUserTokenFromCookies } from '../../../../utils/session';
 
 type PageBodyResponse = {
   department: number;
@@ -58,6 +58,9 @@ const UserPage = ({
   fieldErrors,
 }: InferProps<typeof getServerSideProps>) => {
   const { user, departments } = pageData;
+  const newUserRolesList = formAction.split('newRoles=');
+  const newUserRoles = newUserRolesList ? newUserRolesList[1] : null;
+
   return (
     <>
       <Meta
@@ -96,7 +99,11 @@ const UserPage = ({
             </button>
 
             <CustomLink
-              href={`/super-admin-dashboard/manage-departments?userId=${user.gapUserId}`}
+              href={
+                newUserRoles
+                  ? `/super-admin-dashboard/manage-departments?userId=${user.gapUserId}&newRoles=${newUserRoles}`
+                  : `/super-admin-dashboard/manage-departments?userId=${user.gapUserId}`
+              }
             >
               Manage departments
             </CustomLink>

--- a/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.test.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.test.tsx
@@ -1,15 +1,17 @@
 import '@testing-library/jest-dom';
-import { getContext } from 'gap-web-ui';
-import UserPage, { getServerSideProps } from './change-department.page';
-import { Department, Role, User } from '../../types';
 import { render, screen } from '@testing-library/react';
-import { parseBody } from '../../../../utils/parseBody';
+import { getContext } from 'gap-web-ui';
 import {
   getChangeDepartmentPage,
   updateUserRoles,
 } from '../../../../services/SuperAdminService';
+import { parseBody } from '../../../../utils/parseBody';
+import { getUserTokenFromCookies } from '../../../../utils/session';
+import { Department, Role, User } from '../../types';
+import UserPage, { getServerSideProps } from './change-department.page';
 
 jest.mock('../../../../utils/parseBody');
+jest.mock('../../../../utils/session');
 
 jest.mock('../../../../services/SuperAdminService', () => ({
   getUserById: jest.fn(),
@@ -139,6 +141,7 @@ describe('Change department page', () => {
     });
 
     test('Should update roles if user is being promoted to ADMIN', async () => {
+      (getUserTokenFromCookies as jest.Mock).mockReturnValue('testJWT');
       mockGetChangeDepartmentPage.mockResolvedValueOnce({
         user: getMockUser([getMockRoles()[0], getMockRoles()[1]]),
         departments: [{ id: '4', name: 'hello world' }],


### PR DESCRIPTION
## Description
when assigning a role and selecting a department, if a user clicks on `manage departments`, it now carries the new roles over in the query so that the roles and department can be updated

Ticket # and link
TMI2-702: https://technologyprogramme.atlassian.net/browse/TMI2-702

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
