### PR TITLE
GAP-2497: Date format in submission overview

### DIFF
--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.test.tsx
@@ -67,8 +67,8 @@ describe('should return the correct data for the multiResponse', () => {
     expect(screen.getByText('test2')).toBeDefined();
   });
 
-  it('should return a dash separated string if responseType is Date', () => {
+  it('should return an en-UK formatted date string if responseType is Date', () => {
     render(componentWithDateArray);
-    expect(screen.getByText('01-10-2015')).toBeDefined();
+    expect(screen.getByText('1 October 2015')).toBeDefined();
   });
 });

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+
 interface ProcessMultiResponseProps {
   data: string | string[];
   id: string;
@@ -18,8 +19,20 @@ export const ProcessMultiResponse: FC<ProcessMultiResponseProps> = ({
     ? multiResponseData
     : multiResponseData.split(',');
   const isDate = questionType === 'Date';
-  const formatDate = (date: string[] | string) =>
-    Array.isArray(date) && date.some(Boolean) ? date.join('-') : '-';
+  const formatDate = (date: string[] | string) => {
+    if (Array.isArray(date) && date.some(Boolean)) {
+      return new Date(`${date[1]}-${date[0]}-${date[2]}`).toLocaleDateString(
+        'en-UK',
+        {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        }
+      );
+    }
+
+    return '-';
+  };
 
   const displayMultiResponse = (
     <>


### PR DESCRIPTION
## Description
Date formats on the submission overview page were not en-UK formatted. 

Ticket # and link
[Link to story](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2497)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Introduced a date formatter on the component that outputs date responses on the submission overview page

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
