### PR TITLE
GAP-2436 | download application preview ODT

### DIFF
--- a/packages/admin/src/pages/api/applications/[applicationId]/download-summary.page.tsx
+++ b/packages/admin/src/pages/api/applications/[applicationId]/download-summary.page.tsx
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { downloadSummary } from '../../../../services/ApplicationService';
+import { getSessionIdFromCookies } from '../../../../utils/session';
+import { APIGlobalHandler } from '../../../../utils/apiErrorHandler';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const applicationId = (req.query.applicationId || '').toString();
+  const { data } = await downloadSummary(
+    applicationId,
+    getSessionIdFromCookies(req)
+  );
+
+  res.setHeader('Content-Type', 'application/octet-stream');
+  res.setHeader('Content-Disposition', 'attachment; filename=application.odt');
+  res.send(Buffer.from(data));
+}
+
+export default (req: NextApiRequest, res: NextApiResponse) =>
+  APIGlobalHandler(req, res, handler);

--- a/packages/admin/src/pages/api/applications/[applicationId]/download-summary.test.tsx
+++ b/packages/admin/src/pages/api/applications/[applicationId]/download-summary.test.tsx
@@ -1,0 +1,47 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import axios from 'axios';
+import handler from './download-summary.page';
+
+jest.mock('axios');
+jest.mock('../../../../utils/session');
+jest.mock('next/config', () => () => ({
+  serverRuntimeConfig: {
+    backendHost: 'http://localhost:1',
+  },
+}));
+
+describe('Next API Handler', () => {
+  it('should handle the request and send the file', async () => {
+    const applicationId = 'exampleapplicationId';
+
+    (axios.get as jest.Mock).mockResolvedValue({
+      data: 'mocked file data',
+    });
+
+    const req = {
+      query: { applicationId },
+    } as unknown as NextApiRequest;
+
+    const res = {
+      setHeader: jest.fn(),
+      send: jest.fn(),
+    } as unknown as NextApiResponse;
+    await handler(req, res);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `http://localhost:1/application-forms/${applicationId}/download-summary`,
+      { responseType: 'arraybuffer' }
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/octet-stream'
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename=application.odt'
+    );
+    expect(res.send).toHaveBeenCalledWith(
+      Buffer.from('mocked file data', 'binary')
+    );
+  });
+});

--- a/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
@@ -16,6 +16,7 @@ import InferProps from '../../../types/InferProps';
 import callServiceMethod from '../../../utils/callServiceMethod';
 import { generateErrorPageParams } from '../../../utils/serviceErrorHelpers';
 import { useLayoutEffect, useState, useRef } from 'react';
+import Link from 'next/link';
 
 export const getServerSideProps = async ({
   params,
@@ -217,6 +218,28 @@ const Dashboard = ({
           setNewScrollPosition={setNewScrollPosition}
           formRef={formRef}
         />
+
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+            <h1 className="govuk-heading-s" data-cy="cy-download-header">
+              Preview your application form
+            </h1>
+            <p className="govuk-body">
+              You can{' '}
+              <Link
+                href={`/api/applications/${applicationId}/download-summary`}
+                className="govuk-link govuk-link--no-visited-state"
+              >
+                download a preview of your application form (ODT)
+              </Link>{' '}
+              to share with others. This includes a copy of all of your
+              questions and any associated hint text.
+            </p>
+
+            <hr className="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+          </div>
+        </div>
 
         {applicationStatus === 'PUBLISHED' ? (
           <UnpublishSummary

--- a/packages/admin/src/pages/build-application/[applicationId]/dashboard.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/dashboard.test.tsx
@@ -157,6 +157,15 @@ describe('Dashboard', () => {
         })
       ).toBeFalsy();
     });
+
+    it('should render correct download link', () => {
+      render(<Dashboard {...mockDashboardParams} />);
+      expect(
+        screen.getByRole('link', {
+          name: 'download a preview of your application form (ODT)',
+        })
+      ).toHaveAttribute('href', '/api/applications/87654321/download-summary');
+    });
   });
 
   describe('getServerSideProps', () => {

--- a/packages/admin/src/pages/service-error/index.page.tsx
+++ b/packages/admin/src/pages/service-error/index.page.tsx
@@ -9,6 +9,9 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   );
   const excludeSubPath = query.excludeSubPath === 'true';
 
+  if (serviceError.linkAttributes === undefined)
+    serviceError.linkAttributes = {};
+
   if (serviceError.linkAttributes.href === undefined)
     serviceError.linkAttributes.href = '/dashboard';
 
@@ -40,15 +43,19 @@ const ServiceErrorPage = ({
               <p className="govuk-body">Try again later.</p>
               <p className="govuk-body">{serviceError.errorInformation}</p>
               {serviceError.linkAttributes && (
-                <p className="govuk-body">
-                  <CustomLink
-                    href={serviceError.linkAttributes.href}
-                    excludeSubPath={excludeSubPath}
-                  >
-                    {serviceError.linkAttributes.linkText}
-                  </CustomLink>
-                  {serviceError.linkAttributes.linkInformation}
-                </p>
+                <>
+                  <p className="govuk-body">
+                    <CustomLink
+                      href={serviceError.linkAttributes.href}
+                      excludeSubPath={excludeSubPath}
+                    >
+                      {serviceError.linkAttributes.linkText}
+                    </CustomLink>
+                  </p>
+                  <p className="govuk-body">
+                    {serviceError.linkAttributes.linkInformation}
+                  </p>
+                </>
               )}
             </div>
           </div>

--- a/packages/admin/src/services/ApplicationService.test.ts
+++ b/packages/admin/src/services/ApplicationService.test.ts
@@ -4,6 +4,7 @@ import ApplicationQueryObject from '../types/ApplicationQueryObject';
 import FindApplicationFormStatsResponse from '../types/FindApplicationFormStatsResponse';
 import {
   createNewApplicationForm,
+  downloadSummary,
   findMatchingApplicationForms,
   getApplicationFormSection,
   getApplicationFormSummary,
@@ -266,6 +267,26 @@ describe('ApplicationService', () => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
         `${BASE_APPLICATION_URL}/${grantApplicationId}/status`,
         { headers: { Cookie: 'SESSION=testSessionId;' }, withCredentials: true }
+      );
+    });
+  });
+
+  describe('downloadSummary', () => {
+    it('Should call the expected endpoint to download the summary', async () => {
+      const grantApplicationId = 'a028d000004Osy3BEA';
+      const sessionCookie = 'testSessionId';
+
+      mockedAxios.get.mockResolvedValue({});
+
+      await downloadSummary(grantApplicationId, sessionCookie);
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${BASE_APPLICATION_URL}/${grantApplicationId}/download-summary`,
+        {
+          headers: { Cookie: 'SESSION=testSessionId;' },
+          withCredentials: true,
+          responseType: 'arraybuffer',
+        }
       );
     });
   });

--- a/packages/admin/src/services/ApplicationService.ts
+++ b/packages/admin/src/services/ApplicationService.ts
@@ -151,6 +151,19 @@ const getApplicationStatus = async (
   return response.data;
 };
 
+export async function downloadSummary(
+  applicationId: string,
+  sessionId: string
+) {
+  return await axios.get(
+    `${BASE_APPLICATION_URL}/${applicationId}/download-summary`,
+    {
+      ...axiosSessionConfig(sessionId),
+      responseType: 'arraybuffer',
+    }
+  );
+}
+
 export {
   createNewApplicationForm,
   findMatchingApplicationForms,


### PR DESCRIPTION
## Description

[GAP-2436](https://technologyprogramme.atlassian.net/browse/GAP-2436)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Admins can download an ODT of the application form which contains scheme information and a list of sections and questions within their application form.
https://github.com/cabinetoffice/gap-find-admin-backend/pull/248

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [x] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
