### PR TITLE
TMI2-616: checks application form status before editing

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.page.tsx
@@ -1,4 +1,3 @@
-import Meta from '../../../../../components/layout/Meta';
 import {
   Button,
   FlexibleQuestionPageLayout,
@@ -6,19 +5,20 @@ import {
   ValidationError,
 } from 'gap-web-ui';
 import { GetServerSidePropsContext } from 'next';
-import { patchQuestion } from '../../../../../services/QuestionService';
-import callServiceMethod from '../../../../../utils/callServiceMethod';
-import { getApplicationFormSummary } from '../../../../../services/ApplicationService';
-import { updateSectionStatus } from '../../../../../services/SectionService';
-import { getSessionIdFromCookies } from '../../../../../utils/session';
 import CustomLink from '../../../../../components/custom-link/CustomLink';
+import Meta from '../../../../../components/layout/Meta';
+import { getApplicationFormSummary } from '../../../../../services/ApplicationService';
+import { patchQuestion } from '../../../../../services/QuestionService';
+import { getGrantScheme } from '../../../../../services/SchemeService';
+import { updateSectionStatus } from '../../../../../services/SectionService';
 import InferProps from '../../../../../types/InferProps';
-import styles from './eligibility-statement.module.scss';
+import callServiceMethod from '../../../../../utils/callServiceMethod';
 import {
   generateErrorPageParams,
   generateErrorPageRedirect,
 } from '../../../../../utils/serviceErrorHelpers';
-import { getGrantScheme } from '../../../../../services/SchemeService';
+import { getSessionIdFromCookies } from '../../../../../utils/session';
+import styles from './eligibility-statement.module.scss';
 
 type RequestBody = {
   displayText: string;
@@ -96,7 +96,10 @@ export const getServerSideProps = async ({
     );
   }
 
-  if (appForm.applicationStatus === 'PUBLISHED') {
+  if (
+    appForm.applicationStatus === 'PUBLISHED' ||
+    appForm.applicationStatus === 'REMOVED'
+  ) {
     let grantName;
     try {
       grantName = (await getGrantScheme(appForm.grantSchemeId, sessionId)).name;
@@ -145,7 +148,7 @@ const EligibilityStatement = ({
   applicationStatus,
   version,
 }: InferProps<typeof getServerSideProps>) => {
-  if (applicationStatus === 'PUBLISHED') {
+  if (applicationStatus === 'PUBLISHED' || applicationStatus === 'REMOVED') {
     return (
       <>
         <Meta title={`Eligibility statement preview - Manage a grant`} />

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.page.tsx
@@ -112,6 +112,9 @@ export const getServerSideProps = async ({
 
     return {
       props: {
+        fieldErrors: fieldErrors,
+        formAction: process.env.SUB_PATH + resolvedUrl,
+        csrfToken: res.getHeader('x-csrf-token') as string,
         backButtonHref: `/build-application/${applicationId}/dashboard`,
         grantName: grantName,
         defaultValue: existingDisplayText,

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.test.tsx
@@ -1,14 +1,14 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import axios from 'axios';
+import { merge } from 'lodash';
+import { GetServerSidePropsContext } from 'next';
+import { getGrantScheme } from '../../../../../services/SchemeService';
+import { updateSectionStatus } from '../../../../../services/SectionService';
+import { parseBody } from '../../../../../utils/parseBody';
 import EligibilityStatement, {
   getServerSideProps,
 } from './eligibility-statement.page';
-import { parseBody } from '../../../../../utils/parseBody';
-import { merge } from 'lodash';
-import { updateSectionStatus } from '../../../../../services/SectionService';
-import { getGrantScheme } from '../../../../../services/SchemeService';
-import { GetServerSidePropsContext } from 'next';
 
 jest.mock('axios');
 jest.mock('../../../../../utils/parseBody');
@@ -249,6 +249,9 @@ describe('Eligibility question page page', () => {
 
         expect(result).toEqual({
           props: {
+            fieldErrors: [],
+            formAction: process.env.SUB_PATH + '/resolvedUrl',
+            csrfToken: 'testCSRFToken',
             backButtonHref: '/build-application/testAppId/dashboard',
             defaultValue: 'test display text',
             grantName: 'testGrantName',

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/due-diligence.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/due-diligence.page.tsx
@@ -1,22 +1,22 @@
-import Meta from '../../../../components/layout/Meta';
 import {
+  Button,
   Checkboxes,
   FlexibleQuestionPageLayout,
-  Button,
   ValidationError,
 } from 'gap-web-ui';
-import { getApplicationFormSummary } from '../../../../services/ApplicationService';
-import { ApplicationFormSummary } from '../../../../types/ApplicationForm';
-import { updateSectionStatus } from '../../../../services/SectionService';
-import callServiceMethod from '../../../../utils/callServiceMethod';
-import { getSessionIdFromCookies } from '../../../../utils/session';
+import { GetServerSidePropsContext } from 'next';
 import CustomLink from '../../../../components/custom-link/CustomLink';
+import Meta from '../../../../components/layout/Meta';
+import { getApplicationFormSummary } from '../../../../services/ApplicationService';
+import { updateSectionStatus } from '../../../../services/SectionService';
+import { ApplicationFormSummary } from '../../../../types/ApplicationForm';
+import InferProps from '../../../../types/InferProps';
+import callServiceMethod from '../../../../utils/callServiceMethod';
 import {
   generateErrorPageParams,
   generateErrorPageRedirect,
 } from '../../../../utils/serviceErrorHelpers';
-import InferProps from '../../../../types/InferProps';
-import { GetServerSidePropsContext } from 'next';
+import { getSessionIdFromCookies } from '../../../../utils/session';
 
 export const getServerSideProps = async ({
   resolvedUrl,
@@ -181,7 +181,8 @@ const DueDiligence = ({
             disabled={disabled}
           />
 
-          {applicationStatus === 'PUBLISHED' ? (
+          {applicationStatus === 'PUBLISHED' ||
+          applicationStatus === 'REMOVED' ? (
             <CustomLink
               href={backButtonHref}
               customStyle="govuk-!-font-size-19"

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
@@ -59,6 +59,16 @@ const getServerSideProps = async ({
         permanent: false,
       },
     };
+  } else if (
+    applicationStatus === 'REMOVED' &&
+    (sectionId === 'ELIGIBILITY' || sectionId === 'ESSENTIAL')
+  ) {
+    return {
+      redirect: {
+        destination: `/build-application/${applicationId}/dashboard`,
+        permanent: false,
+      },
+    };
   }
 
   let applicationFormSummary;


### PR DESCRIPTION
Checks application form status. If it's PUBLISHED or REMOVED, admin is redirected to build application dashboard. If the status is not PUBLISHED or REMOVED then admin can edit the application. If the status is REMOVED, the user can only edit custom sections

Ticket # and link
TMI2-616: https://technologyprogramme.atlassian.net/browse/TMI2-616

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
