### PR TITLE
TMI2-616: reverted changes for editing unpublished application

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/eligibility-statement.page.tsx
@@ -96,10 +96,7 @@ export const getServerSideProps = async ({
     );
   }
 
-  if (
-    appForm.applicationStatus === 'PUBLISHED' ||
-    appForm.applicationStatus === 'REMOVED'
-  ) {
+  if (appForm.applicationStatus === 'PUBLISHED') {
     let grantName;
     try {
       grantName = (await getGrantScheme(appForm.grantSchemeId, sessionId)).name;
@@ -151,7 +148,7 @@ const EligibilityStatement = ({
   applicationStatus,
   version,
 }: InferProps<typeof getServerSideProps>) => {
-  if (applicationStatus === 'PUBLISHED' || applicationStatus === 'REMOVED') {
+  if (applicationStatus === 'PUBLISHED') {
     return (
       <>
         <Meta title={`Eligibility statement preview - Manage a grant`} />

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/due-diligence.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/due-diligence.page.tsx
@@ -181,8 +181,7 @@ const DueDiligence = ({
             disabled={disabled}
           />
 
-          {applicationStatus === 'PUBLISHED' ||
-          applicationStatus === 'REMOVED' ? (
+          {applicationStatus === 'PUBLISHED' ? (
             <CustomLink
               href={backButtonHref}
               customStyle="govuk-!-font-size-19"

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
@@ -53,21 +53,7 @@ const getServerSideProps = async ({
     sessionId
   );
 
-  if (
-    applicationStatus === 'PUBLISHED' ||
-    sectionId.toUpperCase() === 'ELIGIBILITY' ||
-    sectionId.toUpperCase() === 'ESSENTIAL'
-  ) {
-    return {
-      redirect: {
-        destination: `/build-application/${applicationId}/dashboard`,
-        permanent: false,
-      },
-    };
-  } else if (
-    applicationStatus === 'REMOVED' &&
-    (sectionId === 'ELIGIBILITY' || sectionId === 'ESSENTIAL')
-  ) {
+  if (applicationStatus === 'PUBLISHED') {
     return {
       redirect: {
         destination: `/build-application/${applicationId}/dashboard`,

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
@@ -53,7 +53,11 @@ const getServerSideProps = async ({
     sessionId
   );
 
-  if (applicationStatus === 'PUBLISHED') {
+  if (
+    applicationStatus === 'PUBLISHED' ||
+    sectionId.toUpperCase() === 'ELIGIBILITY' ||
+    sectionId.toUpperCase() === 'ESSENTIAL'
+  ) {
     return {
       redirect: {
         destination: `/build-application/${applicationId}/dashboard`,

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
@@ -234,6 +234,48 @@ describe('Edit section page', () => {
         });
       });
 
+      it('Should redirect to build application dashboard if sectionId is ELIGIBILITY', async () => {
+        const result = await getServerSideProps(
+          getContext(() => ({
+            params: {
+              applicationId: 'testApplicationId',
+              sectionId: 'ELIGIBILITY',
+            },
+            query: {
+              scrollPosition: '0',
+            },
+          }))
+        );
+
+        expectObjectEquals(result, {
+          redirect: {
+            destination: '/build-application/testApplicationId/dashboard',
+            permanent: false,
+          },
+        });
+      });
+
+      it('Should redirect to build application dashboard if sectionId is ESSENTIAL', async () => {
+        const result = await getServerSideProps(
+          getContext(() => ({
+            params: {
+              applicationId: 'testApplicationId',
+              sectionId: 'ESSENTIAL',
+            },
+            query: {
+              scrollPosition: '0',
+            },
+          }))
+        );
+
+        expectObjectEquals(result, {
+          redirect: {
+            destination: '/build-application/testApplicationId/dashboard',
+            permanent: false,
+          },
+        });
+      });
+
       it('Should redirect to service error page if section is not found', async () => {
         const result = await getServerSideProps(
           getContext(() => ({

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
@@ -234,48 +234,6 @@ describe('Edit section page', () => {
         });
       });
 
-      it('Should redirect to build application dashboard if sectionId is ELIGIBILITY', async () => {
-        const result = await getServerSideProps(
-          getContext(() => ({
-            params: {
-              applicationId: 'testApplicationId',
-              sectionId: 'ELIGIBILITY',
-            },
-            query: {
-              scrollPosition: '0',
-            },
-          }))
-        );
-
-        expectObjectEquals(result, {
-          redirect: {
-            destination: '/build-application/testApplicationId/dashboard',
-            permanent: false,
-          },
-        });
-      });
-
-      it('Should redirect to build application dashboard if sectionId is ESSENTIAL', async () => {
-        const result = await getServerSideProps(
-          getContext(() => ({
-            params: {
-              applicationId: 'testApplicationId',
-              sectionId: 'ESSENTIAL',
-            },
-            query: {
-              scrollPosition: '0',
-            },
-          }))
-        );
-
-        expectObjectEquals(result, {
-          redirect: {
-            destination: '/build-application/testApplicationId/dashboard',
-            permanent: false,
-          },
-        });
-      });
-
       it('Should redirect to service error page if section is not found', async () => {
         const result = await getServerSideProps(
           getContext(() => ({


### PR DESCRIPTION
## Description
Reverted changes which made essential and required checks sections uneditable while unpublished.

- A user can never edit eligibility or required checks sections but navigating to scheme/{schemeId)/{sectionId) regardless of published state
- A user can edit eligibility statement and due-diligence checks when the application is in draft or removed state

Ticket # and link
TMI2-616: https://technologyprogramme.atlassian.net/browse/TMI2-616

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
