### PR TITLE
GAP-2505: Remove references to 'scheme-list'

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/getServerSideProps.tsx
@@ -110,7 +110,7 @@ const getServerSideProps = async ({
 const errorProps: ServiceError = {
   errorInformation: 'Something went wrong while trying to edit a section',
   linkAttributes: {
-    href: `/scheme-list`,
+    href: `/dashboard`,
     linkText: 'Please find your scheme application form and continue.',
     linkInformation: 'Your previous progress has been saved.',
   },

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/index/index.test.tsx
@@ -292,7 +292,7 @@ describe('Edit section page', () => {
         expectObjectEquals(result, {
           redirect: {
             destination:
-              '/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to edit a section","linkAttributes":{"href":"/scheme-list","linkText":"Please find your scheme application form and continue.","linkInformation":"Your previous progress has been saved."}}',
+              '/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to edit a section","linkAttributes":{"href":"/dashboard","linkText":"Please find your scheme application form and continue.","linkInformation":"Your previous progress has been saved."}}',
             permanent: false,
           },
         });
@@ -308,7 +308,7 @@ describe('Edit section page', () => {
         expectObjectEquals(result, {
           redirect: {
             destination:
-              '/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to edit a section","linkAttributes":{"href":"/scheme-list","linkText":"Please find your scheme application form and continue.","linkInformation":"Your previous progress has been saved."}}',
+              '/service-error?serviceErrorProps={"errorInformation":"Something went wrong while trying to edit a section","linkAttributes":{"href":"/dashboard","linkText":"Please find your scheme application form and continue.","linkInformation":"Your previous progress has been saved."}}',
             permanent: false,
           },
         });

--- a/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/dashboard.page.tsx
@@ -74,7 +74,7 @@ export const getServerSideProps = async ({
       errorInformation:
         'Something went wrong while trying to create an application',
       linkAttributes: {
-        href: `/scheme-list`,
+        href: `/dashboard`,
         linkText: 'Please find your scheme application form and continue.',
         linkInformation: 'Your previous progress has been saved.',
       },

--- a/packages/admin/src/pages/build-application/[applicationId]/dashboard.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/dashboard.test.tsx
@@ -173,7 +173,7 @@ describe('Dashboard', () => {
       errorInformation:
         'Something went wrong while trying to create an application',
       linkAttributes: {
-        href: `/scheme-list`,
+        href: `/dashboard`,
         linkText: 'Please find your scheme application form and continue.',
         linkInformation: 'Your previous progress has been saved.',
       },

--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/preview/preview.test.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/preview/preview.test.tsx
@@ -87,7 +87,7 @@ describe('getServerSideProps', () => {
       const expectedResult = {
         redirect: {
           destination:
-            '/error-page/code/GRANT_ADVERT_NOT_FOUND?href=/scheme-list',
+            '/error-page/code/GRANT_ADVERT_NOT_FOUND?href=/dashboard',
           statusCode: 302,
         } as Redirect,
       };

--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/section-overview.page.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/section-overview.page.tsx
@@ -68,7 +68,7 @@ export const getServerSideProps = async ({
   } catch (err) {
     const error = err as AxiosError;
     const errorMessageObject = error.response?.data as CustomError;
-    return generateErrorPageRedirectV2(errorMessageObject.code, '/scheme-list');
+    return generateErrorPageRedirectV2(errorMessageObject.code, '/dashboard');
   }
 };
 

--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/section-overview.test.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/section-overview.test.tsx
@@ -80,7 +80,7 @@ const mockedGetSectionOverviewPageContentResponse: GetSectionOverviewPageContent
 
 const expectedGetServerSideRedirection = {
   redirect: {
-    destination: '/error-page/code/GRANT_ADVERT_NOT_FOUND?href=/scheme-list',
+    destination: '/error-page/code/GRANT_ADVERT_NOT_FOUND?href=/dashboard',
     statusCode: 302,
   },
 };

--- a/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/summary.test.tsx
+++ b/packages/admin/src/pages/scheme/[schemeId]/advert/[advertId]/summary/summary.test.tsx
@@ -146,8 +146,7 @@ describe('getServerSideProps', () => {
 
     const expectedResult = {
       redirect: {
-        destination:
-          '/error-page/code/GRANT_ADVERT_NOT_FOUND?href=/scheme-list',
+        destination: '/error-page/code/GRANT_ADVERT_NOT_FOUND?href=/dashboard',
         statusCode: 302,
       } as Redirect,
     };


### PR DESCRIPTION
## Description

Ticket # and link [GAP-2505](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2505)

Summary of the changes and the related issue. List any dependencies that are required for this change: 
Removes references to /scheme-list in old error pages to now redirect to /dashboard.

## Type of change

Please check the relevant options.

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2505]: https://technologyprogramme.atlassian.net/browse/GAP-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ