### PR TITLE
TMI2-718: don't update role if department is undefined

### DIFF
--- a/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.page.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.page.tsx
@@ -22,7 +22,11 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     const newUserRolesParam = context.query?.newRoles as string | undefined;
     const newUserRoles = newUserRolesParam?.split?.(',');
 
-    if (newUserRoles && newRolesAreAdminRoles(newUserRoles)) {
+    if (
+      newUserRoles &&
+      newRolesAreAdminRoles(newUserRoles) &&
+      body.department
+    ) {
       await updateUserRoles(userId, newUserRoles, jwt, body.department);
     }
     return await updateDepartment(userId, body.department, jwt);

--- a/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.test.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.test.tsx
@@ -113,6 +113,7 @@ describe('Change department page', () => {
       expect(
         screen.getByText('There is a problem').nextSibling
       ).toHaveTextContent('Select a department');
+      expect(updateUserRoles).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.test.tsx
+++ b/packages/admin/src/pages/super-admin-dashboard/user/[id]/change-department.test.tsx
@@ -93,7 +93,7 @@ describe('Change department page', () => {
       expect(screen.getByText('Manage departments')).toBeVisible();
     });
 
-    test('Should throw an error if no department is selected', async () => {
+    test('Should throw an error if no department is selected and do not update user role', async () => {
       const component = (
         <UserPage
           csrfToken="csrf"


### PR DESCRIPTION
## Description
The user's role won't be updated until a department is selected to avoid an applicant being promoted to a different role without a department 

Ticket # and link
TMI2-718: https://technologyprogramme.atlassian.net/browse/TMI2-718

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
