### PR TITLE
Map v2 Application form section data

### DIFF
--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/unpublished-preview/index.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/unpublished-preview/index.test.tsx
@@ -208,6 +208,7 @@ describe('getServerSideProps for unpublished-preview index page', () => {
   const getContext = (overrides: any = {}) =>
     merge(
       {
+        query: {},
         params: {
           applicationId: mockApplicationId,
           sectionId: mockCustomSection.sectionId,
@@ -243,7 +244,8 @@ describe('getServerSideProps for unpublished-preview index page', () => {
         expect(getApplicationFormSection).toHaveBeenCalledWith(
           '1',
           'mockCustomSection',
-          'testSessionId'
+          'testSessionId',
+          false
         );
       });
 
@@ -282,7 +284,8 @@ describe('getServerSideProps for unpublished-preview index page', () => {
           'testSessionId',
           '1',
           'mockCustomSection',
-          'shortAnswer'
+          'shortAnswer',
+          false
         );
       });
 

--- a/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/unpublished-preview/index.test.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/[sectionId]/[questionId]/unpublished-preview/index.test.tsx
@@ -19,63 +19,64 @@ const shortAnswerQ = {
   responseType: ResponseTypeEnum.ShortAnswer,
   validation: {},
 };
-const longAnswerQ: ApplicationFormQuestion = {
+const longAnswerQ = {
   questionId: 'longAnswer',
   fieldTitle: 'Question 2 - long',
   hintText: 'long answer question',
-  responseType: 'LongAnswer',
+  responseType: ResponseTypeEnum.LongAnswer,
   validation: {},
 };
-const yesNoQ: ApplicationFormQuestion = {
+
+const yesNoQ = {
   questionId: 'yesNo',
   fieldTitle: 'Question 3 - Yes/No',
   hintText: 'Yes/No question',
-  responseType: 'YesNo',
+  responseType: ResponseTypeEnum.YesNo,
   validation: {},
 };
-const multipleChoiceQ: ApplicationFormQuestion = {
+const multipleChoiceQ = {
   questionId: 'multiChoice',
   fieldTitle: 'Question 4 - Multiple Choice',
   hintText: 'Multiple choice question',
-  responseType: 'Dropdown',
+  responseType: ResponseTypeEnum.Dropdown,
   options: ['One', 'Two', 'Three'],
   validation: {},
 };
-const multipleSelectQ: ApplicationFormQuestion = {
+const multipleSelectQ = {
   questionId: 'multiSelect',
   fieldTitle: 'Question 5 - Multiple Select',
   hintText: 'Multiple select question',
-  responseType: 'MultipleSelection',
+  responseType: ResponseTypeEnum.MultipleSelection,
   options: ['One', 'Two', 'Three'],
   validation: {},
 };
-const docUploadQ: ApplicationFormQuestion = {
+const docUploadQ = {
   questionId: '0c92d26f-d2c6-4ae3-8cfb-b244ee579153',
   fieldTitle: 'Question 6 - Document Upload',
   hintText: 'Document upload question',
-  responseType: 'SingleFileUpload',
+  responseType: ResponseTypeEnum.SingleFileUpload,
   validation: {},
 };
-const dateSelectQ: ApplicationFormQuestion = {
+const dateSelectQ = {
   questionId: '8466844a-25ff-475e-aa2f-fe69ef747add',
   fieldTitle: 'Question 7 - Date ',
   hintText: 'Date selection question',
-  responseType: 'Date',
+  responseType: ResponseTypeEnum.Date,
   validation: {},
 };
-const addressInputQ: ApplicationFormQuestion = {
+const addressInputQ = {
   questionId: 'orgAddress',
   profileField: 'ORG_ADDRESS',
   fieldTitle: "Enter your organisation's address",
-  responseType: 'AddressInput',
+  responseType: ResponseTypeEnum.AddressInput,
   validation: {},
 };
-const fundAmountQ: ApplicationFormQuestion = {
+const fundAmountQ = {
   questionId: 'fundingAmount',
   fieldPrefix: '£',
   fieldTitle: 'How much does your organisation require as a grant?',
   hintText: 'Please enter whole pounds only',
-  responseType: 'Numeric',
+  responseType: ResponseTypeEnum.Numeric,
   validation: {},
 };
 
@@ -120,7 +121,7 @@ const getQuestionProps = (questionIndex: number) => {
 const previewText = screen.findByText('Question preview');
 const previewNext = screen.findByText('Preview next question');
 const backToOverview = screen.findByText('Back to overview');
-const backButton = screen.findByText('Back');
+
 describe('UnpublishedPreviewQuestion component', () => {
   describe('Rendering of buttons and text', () => {
     it('Should render a meta title', () => {
@@ -222,6 +223,20 @@ describe('getServerSideProps for unpublished-preview index page', () => {
 
   describe('Fetching question data', () => {
     describe('Service call to get the current section', () => {
+      it('should pass isV2Scheme into props', async () => {
+        const res = (await getServerSideProps(
+          getContext({ query: { v2: 'true' } })
+        )) as {
+          props: {
+            nextPreviewHref: string | null;
+          };
+        };
+
+        expect(res.props.nextPreviewHref).toEqual(
+          '/build-application/1/mockCustomSection/longAnswer/unpublished-preview?v2=true'
+        );
+      });
+
       it('should fetch the relevant section', async () => {
         await getServerSideProps(getContext());
         expect(getApplicationFormSection).toHaveBeenCalledTimes(1);

--- a/packages/admin/src/pages/build-application/[applicationId]/section-overview.page.tsx
+++ b/packages/admin/src/pages/build-application/[applicationId]/section-overview.page.tsx
@@ -9,6 +9,8 @@ import InferProps from '../../../types/InferProps';
 import CustomLink from '../../../components/custom-link/CustomLink';
 import Meta from '../../../components/layout/Meta';
 import { ApplicationFormSection } from '../../../types/ApplicationForm';
+import { getGrantScheme } from '../../../services/SchemeService';
+import { mapV2Sections } from '../../../utils/applicationSummaryHelper';
 
 export const getServerSideProps = async ({
   req,
@@ -16,15 +18,27 @@ export const getServerSideProps = async ({
 }: GetServerSidePropsContext) => {
   const applicationId = params!.applicationId as string;
   try {
-    const { sections, applicationName } = await getApplicationFormSummary(
-      applicationId,
+    const { sections, grantSchemeId, applicationName } =
+      await getApplicationFormSummary(
+        applicationId,
+        getSessionIdFromCookies(req)
+      );
+
+    const { version } = await getGrantScheme(
+      grantSchemeId,
       getSessionIdFromCookies(req)
     );
+
+    let v2SchemeMappedSections;
+
+    if (version !== '1') {
+      v2SchemeMappedSections = mapV2Sections(sections);
+    }
 
     return {
       props: {
         applicationId,
-        sections,
+        sections: v2SchemeMappedSections ?? sections,
         applicationName,
       },
     };

--- a/packages/admin/src/services/ApplicationService.ts
+++ b/packages/admin/src/services/ApplicationService.ts
@@ -75,27 +75,23 @@ const getApplicationFormSection = async (
   sessionId: string,
   isV2Scheme?: boolean
 ) => {
-  const sectionsNeedMapped =
+  const sectionNeedsMapped =
     isV2Scheme &&
     ['ORGANISATION_DETAILS', 'FUNDING_DETAILS'].includes(sectionId);
 
   const { data } = await axios.get<ApplicationFormSection>(
     `${BASE_APPLICATION_URL}/${applicationId}/sections/${
-      sectionsNeedMapped ? 'ESSENTIAL' : sectionId
+      sectionNeedsMapped ? 'ESSENTIAL' : sectionId
     }`,
     axiosSessionConfig(sessionId)
   );
 
-  let v2SectionData = null;
+  if (!sectionNeedsMapped) return data;
 
-  if (sectionsNeedMapped) {
-    v2SectionData = mapSingleSection(
-      data,
-      sectionId as 'ORGANISATION_DETAILS' | 'FUNDING_DETAILS'
-    );
-  }
-
-  return v2SectionData ?? data;
+  return mapSingleSection(
+    data,
+    sectionId as 'ORGANISATION_DETAILS' | 'FUNDING_DETAILS'
+  );
 };
 
 const updateApplicationFormStatus = async (

--- a/packages/admin/src/services/QuestionService.ts
+++ b/packages/admin/src/services/QuestionService.ts
@@ -56,11 +56,18 @@ const getQuestion = async (
   sessionId: string,
   applicationId: string,
   sectionId: string,
-  questionId: string
+  questionId: string,
+  isV2Scheme?: boolean
 ): Promise<ApplicationFormQuestion> => {
+  const isEssentialQuestion =
+    isV2Scheme &&
+    ['ORGANISATION_DETAILS', 'FUNDING_DETAILS'].includes(sectionId);
+
+  const section = isEssentialQuestion ? 'ESSENTIAL' : sectionId;
+
   return (
     await axios.get(
-      `${BASE_APPLICATION_URL}/${applicationId}/sections/${sectionId}/questions/${questionId}`,
+      `${BASE_APPLICATION_URL}/${applicationId}/sections/${section}/questions/${questionId}`,
       axiosSessionConfig(sessionId)
     )
   ).data;

--- a/packages/admin/src/utils/applicationSummaryHelper.test.tsx
+++ b/packages/admin/src/utils/applicationSummaryHelper.test.tsx
@@ -1,0 +1,54 @@
+import {
+  ApplicationFormQuestion,
+  ApplicationFormSection,
+} from '../types/ApplicationForm';
+import { mapSingleSection, mapV2Sections } from './applicationSummaryHelper';
+
+describe('Test mapSingleSection', () => {
+  const essentialSection = {
+    sectionId: 'ESSENTIAL',
+    sectionTitle: 'Essential',
+    sectionStatus: 'COMPLETE' as const,
+    questions: [
+      { questionId: 'APPLICANT_TYPE' },
+      { questionId: 'APPLICANT_ORG_NAME' },
+      { questionId: 'APPLICANT_AMOUNT' },
+    ] as ApplicationFormQuestion[],
+  };
+
+  it('should map section correctly for ORGANISATION_DETAILS', () => {
+    const mappedSection = mapSingleSection(
+      essentialSection,
+      'ORGANISATION_DETAILS'
+    );
+    expect(mappedSection.questions).toEqual([
+      { questionId: 'APPLICANT_TYPE' },
+      { questionId: 'APPLICANT_ORG_NAME' },
+    ]);
+  });
+
+  it('should map section correctly for FUNDING_DETAILS', () => {
+    const mappedSection = mapSingleSection(essentialSection, 'FUNDING_DETAILS');
+    expect(mappedSection.questions).toEqual([
+      { questionId: 'APPLICANT_AMOUNT' },
+    ]);
+  });
+});
+
+describe('Test mapV2Sections', () => {
+  const sections = [
+    { sectionId: 'ELIGIBILITY', questions: [] as ApplicationFormQuestion[] },
+    { sectionId: 'ESSENTIAL', questions: [] as ApplicationFormQuestion[] },
+    { sectionId: 'CUSTOM_SECTION', questions: [] as ApplicationFormQuestion[] },
+  ] as ApplicationFormSection[];
+
+  it('should map sections correctly', () => {
+    const mappedSections = mapV2Sections(sections);
+
+    expect(mappedSections).toHaveLength(4);
+    expect(mappedSections[0].sectionId).toBe('ELIGIBILITY');
+    expect(mappedSections[1].sectionId).toBe('ORGANISATION_DETAILS');
+    expect(mappedSections[2].sectionId).toBe('FUNDING_DETAILS');
+    expect(mappedSections[3].sectionId).toBe('CUSTOM_SECTION');
+  });
+});

--- a/packages/admin/src/utils/applicationSummaryHelper.ts
+++ b/packages/admin/src/utils/applicationSummaryHelper.ts
@@ -1,0 +1,77 @@
+import {
+  ApplicationFormQuestion,
+  ApplicationFormSection,
+} from '../types/ApplicationForm';
+
+const ORGANISATION_DETAILS = 'ORGANISATION_DETAILS';
+const FUNDING_DETAILS = 'FUNDING_DETAILS';
+
+const getOrgDetails = (): ApplicationFormSection => ({
+  sectionId: 'ORGANISATION_DETAILS',
+  sectionTitle: 'Your details',
+  sectionStatus: 'COMPLETE' as const,
+  questions: [] as ApplicationFormQuestion[],
+});
+
+const getFundingDetails = (): ApplicationFormSection => ({
+  sectionId: 'FUNDING_DETAILS',
+  sectionTitle: 'Funding',
+  sectionStatus: 'COMPLETE' as const,
+  questions: [] as ApplicationFormQuestion[],
+});
+
+const V2_QUESTION_MAP = {
+  [ORGANISATION_DETAILS]: [
+    'APPLICANT_TYPE',
+    'APPLICANT_ORG_NAME',
+    'APPLICANT_ORG_ADDRESS',
+    'APPLICANT_ORG_COMPANIES_HOUSE',
+    'APPLICANT_ORG_CHARITY_NUMBER',
+  ],
+  [FUNDING_DETAILS]: ['APPLICANT_AMOUNT', 'BENEFITIARY_LOCATION'],
+};
+
+const createV2SchemeSections = (
+  sections: ApplicationFormSection[],
+  essentialSectionIndex: number
+) => {
+  const essentialSection = sections[essentialSectionIndex];
+
+  const orgDetails = mapSingleSection(essentialSection, ORGANISATION_DETAILS);
+  const fundingDetails = mapSingleSection(essentialSection, FUNDING_DETAILS);
+
+  return { orgDetails, fundingDetails };
+};
+
+export const mapSingleSection = (
+  essentialSection: ApplicationFormSection,
+  requestedSection: typeof ORGANISATION_DETAILS | typeof FUNDING_DETAILS
+) => {
+  const newSection =
+    requestedSection === ORGANISATION_DETAILS
+      ? getOrgDetails()
+      : getFundingDetails();
+
+  essentialSection.questions!.forEach((question) => {
+    if (V2_QUESTION_MAP[requestedSection].includes(question.questionId))
+      newSection.questions!.push(question);
+  });
+
+  return newSection;
+};
+
+export const mapV2Sections = (sections: ApplicationFormSection[]) => {
+  const mappedSections = sections;
+
+  const essentialSectionIndex = sections.findIndex(
+    (section) => section.sectionId === 'ESSENTIAL'
+  );
+  const { orgDetails, fundingDetails } = createV2SchemeSections(
+    sections,
+    essentialSectionIndex
+  );
+
+  //Remove the essentials section and replace it with the new sections.
+  mappedSections.splice(essentialSectionIndex, 1, orgDetails, fundingDetails);
+  return mappedSections;
+};

--- a/packages/admin/src/utils/applicationSummaryHelper.ts
+++ b/packages/admin/src/utils/applicationSummaryHelper.ts
@@ -20,7 +20,7 @@ const getFundingDetails = (): ApplicationFormSection => ({
   questions: [] as ApplicationFormQuestion[],
 });
 
-const V2_QUESTION_MAP = {
+export const V2_QUESTION_MAP = {
   [ORGANISATION_DETAILS]: [
     'APPLICANT_TYPE',
     'APPLICANT_ORG_NAME',


### PR DESCRIPTION
## Description

Ticket # and link

Applications always have a v1 shaped `definition`. This definition is expected when we see the initial view of the application (when the admin initially creates it).

When we 'preview' the application we want to render the applicant view (v2 shaped)

This pr adds conditional mapping onto the application summary response so we can render a v2 scheme preview instead of v1 on preview pages.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
