### PR TITLE
GAP-2596: Refresh JWT via a 307 to preserve POSTs

### DIFF
--- a/packages/admin/src/middleware.page.ts
+++ b/packages/admin/src/middleware.page.ts
@@ -17,35 +17,33 @@ const authenticateRequest = async (req: NextRequest, res: NextResponse) => {
       url += `?${generateRedirectUrl(req)}`;
     }
     logger.info(`Not authorised - logging in via: ${url}`);
-    return NextResponse.redirect(url);
+    return NextResponse.redirect(url, { status: 302 });
   }
 
   const isValidSession = await isValidAdminSession(authCookie);
   if (!isValidSession) {
     const url = getLoginUrl({ redirectToApplicant: true });
     logger.info(`Admin session invalid - logging in via applicant app: ${url}`);
-    return NextResponse.redirect(url, {
-      status: 302,
-    });
+    return NextResponse.redirect(url, { status: 302 });
   }
 
   if (hasJwtExpired(userJwtCookie)) {
     const url = `${getLoginUrl()}?${generateRedirectUrl(req)}`;
     logger.info(`Jwt expired - logging in via: ${url}`);
-    return NextResponse.redirect(url);
+    return NextResponse.redirect(url, { status: 302 });
   }
 
   if (isJwtExpiringSoon(userJwtCookie)) {
     const url = `${process.env.REFRESH_URL}?${generateRedirectUrl(req)}`;
     logger.info(`Refreshing JWT - redircting to: ${url}`);
-    return NextResponse.redirect(url);
+    return NextResponse.redirect(url, { status: 307 });
   }
 
   if (isAdBuilderRedirectAndDisabled(req)) {
     const url = req.nextUrl.clone();
     url.pathname = '/404';
     logger.info(`Ad builder disabled - redirecting to 404: ${url.toString()}`);
-    return NextResponse.redirect(url);
+    return NextResponse.redirect(url, { status: 302 });
   }
 
   logger.info('User is authorised');

--- a/packages/admin/src/middleware.test.ts
+++ b/packages/admin/src/middleware.test.ts
@@ -130,7 +130,7 @@ describe('middleware', () => {
 
     const res = await middleware(req);
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(302);
     expect(res.headers.get('Location')).toBe(
       `${loginUrl}?redirectUrl=http://localhost:3000/dashboard`
     );


### PR DESCRIPTION
Need 307s to preserve post requests and forward them onwards when refreshing JWTs
- (Applicant side already seems to do this locally)