### PR TITLE
Gap 2587/redirect to404when not allowed on a page

### DIFF
--- a/packages/admin/src/middleware.page.ts
+++ b/packages/admin/src/middleware.page.ts
@@ -11,10 +11,9 @@ const authenticateRequest = async (req: NextRequest, res: NextResponse) => {
   const authCookie = req.cookies.get('session_id');
   const userJwtCookie = req.cookies.get(process.env.JWT_COOKIE_NAME);
 
-  await csrfMiddleware(req, res);
-  //means that the user is logged in but not as an admin/superAdmin(otherwise they would have had the session_id cookie set)
   const isLoggedIn = !!userJwtCookie;
-  const isLoggedInAsAdmin = !!authCookie
+  const isLoggedInAsAdmin = !!authCookie;
+  // means that the user is logged in but not as an admin/superAdmin (otherwise they would have had the session_id cookie set)
   if (isLoggedIn && !isLoggedInAsAdmin) {
     const url = getLoginUrl({ redirectTo404: true });
     logger.info(

--- a/packages/admin/src/middleware.page.ts
+++ b/packages/admin/src/middleware.page.ts
@@ -13,15 +13,15 @@ const authenticateRequest = async (req: NextRequest, res: NextResponse) => {
 
   await csrfMiddleware(req, res);
   //means that the user is logged in but not as an admin/superAdmin(otherwise they would have had the session_id cookie set)
-  if (!authCookie && userJwtCookie) {
+  const isLoggedIn = !!userJwtCookie;
+  const isLoggedInAsAdmin = !!authCookie
+  if (isLoggedIn && !isLoggedInAsAdmin) {
     const url = getLoginUrl({ redirectTo404: true });
     logger.info(
       `User is not an admin - redirecting it to appropriate app 404 page`
     );
-    return NextResponse.redirect(url);
-  }
-  //means user is not logged in
-  if (!authCookie || !userJwtCookie) {
+    return NextResponse.redirect(url, { status: 302 });
+  } else if (!isLoggedIn || !isLoggedInAsAdmin) {
     let url = getLoginUrl();
     if (isSubmissionExportLink(req)) {
       url += `?${generateRedirectUrl(req)}`;

--- a/packages/admin/src/utils/general.ts
+++ b/packages/admin/src/utils/general.ts
@@ -26,12 +26,16 @@ const getObjEntriesByKeySubstr = (substr: string, obj: object) => {
 
 type GetLoginUrlOptions = {
   redirectToApplicant?: boolean;
+  redirectTo404?: boolean;
 };
 
 const getLoginUrl = (options?: GetLoginUrlOptions) => {
   const oneLoginEnabled = process.env.ONE_LOGIN_ENABLED === 'true';
   if (options?.redirectToApplicant && oneLoginEnabled) {
     return `${process.env.V2_LOGIN_URL}?redirectUrl=${process.env.APPLICANT_DOMAIN}/dashboard`;
+  }
+  if (options?.redirectTo404 && oneLoginEnabled) {
+    return `${process.env.V2_LOGIN_URL}?redirectUrl=/404`;
   }
   return oneLoginEnabled
     ? (process.env.V2_LOGIN_URL as string)

--- a/packages/applicant/src/pages/404.page.tsx
+++ b/packages/applicant/src/pages/404.page.tsx
@@ -26,7 +26,7 @@ const Custom404 = () => {
             </p>
             <p className="govuk-body">
               To return to the dashboard, please visit the{' '}
-              <Link href="/" className="govuk-link">
+              <Link href="/dashboard" className="govuk-link">
                 dashboard
               </Link>{' '}
               page.


### PR DESCRIPTION
[GAP-2587](https://technologyprogramme.atlassian.net/browse/GAP-2587)

## Description
if a user was logged in, and tried to access any other subdomain not within his role capabilities, the user service was redirecting the user to its dashboard.
we now implemented logic to redirect the user to a 404/page based on the user role

Summary of the changes and the related issue. List any dependencies that are required for this change:
https://github.com/cabinetoffice/gap-user-service/pull/202

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [x] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2587]: https://technologyprogramme.atlassian.net/browse/GAP-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ