### PR TITLE
GAP-2530: fix invalid date in safari

### DIFF
--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.test.tsx
@@ -40,6 +40,14 @@ const componentWithDateArray = (
     questionType={'Date'}
   />
 );
+const componentWithInvalidDateArray = (
+  <ProcessMultiResponse
+    data={['', '', '']}
+    id={''}
+    cyTag={''}
+    questionType={'Date'}
+  />
+);
 describe('should return the correct data for the multiResponse', () => {
   it('should return a hyphen if there is no multiResponse', () => {
     render(componentEmptyData);
@@ -70,5 +78,10 @@ describe('should return the correct data for the multiResponse', () => {
   it('should return an en-UK formatted date string if responseType is Date', () => {
     render(componentWithDateArray);
     expect(screen.getByText('1 October 2015')).toBeDefined();
+  });
+
+  it('should return - if responseType is Date but date is invalid', () => {
+    render(componentWithInvalidDateArray);
+    expect(screen.getByText('-')).toBeDefined();
   });
 });

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/processMultiResponse.tsx
@@ -21,7 +21,8 @@ export const ProcessMultiResponse: FC<ProcessMultiResponseProps> = ({
   const isDate = questionType === 'Date';
   const formatDate = (date: string[] | string) => {
     if (Array.isArray(date) && date.some(Boolean)) {
-      return new Date(`${date[1]}-${date[0]}-${date[2]}`).toLocaleDateString(
+      // Must use slashes or Safari will render `Invalid date`
+      return new Date(`${date[1]}/${date[0]}/${date[2]}`).toLocaleDateString(
         'en-UK',
         {
           day: 'numeric',


### PR DESCRIPTION
## Description

[GAP-2530](https://technologyprogramme.atlassian.net/browse/GAP-2530)

fix invalid date in safari by changing hyphens to slashes

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2530]: https://technologyprogramme.atlassian.net/browse/GAP-2530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ