### PR TITLE
GAP-2795 Funding Amount Issue For Multi Applications

### DIFF
--- a/packages/applicant/src/pages/api/create-submission.page.tsx
+++ b/packages/applicant/src/pages/api/create-submission.page.tsx
@@ -132,9 +132,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     if (mandatoryQuestionData.submissionId) {
       // This mandatory question is already linked to an earlier submission (a multi-application
-      // "apply again"). Create a fresh per-submission mandatory question so each submission keeps
-      // its own funding details, rather than re-pointing and overwriting the shared record.
-      await grantMandatoryQuestionService.createMandatoryQuestionForNewSubmission(
+      // "apply again"). Ensure this new submission owns its own mandatory question so each submission
+      // keeps its own funding details, rather than re-pointing and overwriting the shared record.
+      await grantMandatoryQuestionService.ensureMandatoryQuestionForSubmission(
         jwt,
         submissionId
       );

--- a/packages/applicant/src/pages/api/create-submission.page.tsx
+++ b/packages/applicant/src/pages/api/create-submission.page.tsx
@@ -130,19 +130,32 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       submissionName || undefined
     );
 
-    await grantMandatoryQuestionService.updateMandatoryQuestion(
-      jwt,
-      mandatoryQuestionId,
-      'creatingSubmissionFromMandatoryQuestion',
-      {
-        submissionId,
-        mandatoryQuestionsComplete: true,
-      }
-    );
-
-    logger.info(
-      `Submission has been added to mandatory question: ${mandatoryQuestionId}`
-    );
+    if (mandatoryQuestionData.submissionId) {
+      // This mandatory question is already linked to an earlier submission (a multi-application
+      // "apply again"). Create a fresh per-submission mandatory question so each submission keeps
+      // its own funding details, rather than re-pointing and overwriting the shared record.
+      await grantMandatoryQuestionService.createMandatoryQuestionForNewSubmission(
+        jwt,
+        submissionId
+      );
+      logger.info(
+        `Created a new mandatory question for submission ${submissionId} (multiple submissions).`
+      );
+    } else {
+      // First submission for this mandatory question: link it as normal.
+      await grantMandatoryQuestionService.updateMandatoryQuestion(
+        jwt,
+        mandatoryQuestionId,
+        'creatingSubmissionFromMandatoryQuestion',
+        {
+          submissionId,
+          mandatoryQuestionsComplete: true,
+        }
+      );
+      logger.info(
+        `Submission has been added to mandatory question: ${mandatoryQuestionId}`
+      );
+    }
 
     // Use 303 See Other to force GET redirect after POST
     return res.redirect(

--- a/packages/applicant/src/pages/api/create-submission.test.tsx
+++ b/packages/applicant/src/pages/api/create-submission.test.tsx
@@ -228,6 +228,75 @@ describe('API Handler Tests', () => {
     );
   });
 
+  it('should create a fresh mandatory question for a subsequent multi-application submission', async () => {
+    const getAdvertBySchemeIdResponse = {
+      ...advertDTO,
+      isInternal: true,
+      grantApplicationId: 'grantApplicationId',
+    };
+
+    const getGrantApplicationResponse: GrantApplication = {
+      id: '1',
+      version: 2,
+      created: '',
+      lastUpdated: '',
+      lastUpdatedBy: 1,
+      applicationName: 'application name',
+      applicationStatus: 'PUBLISHED',
+      definition: null,
+      allowsMultipleSubmissions: true,
+    } as unknown as GrantApplication;
+
+    GrantSchemeService.getInstance.mockReturnValue({
+      getGrantSchemeById: jest.fn().mockResolvedValue({
+        grantAdverts: [getAdvertBySchemeIdResponse],
+        grantApplication: getGrantApplicationResponse,
+      }),
+      hasSchemeInternalApplication: jest.fn().mockResolvedValue({
+        hasAdvertPublished: true,
+        hasInternalApplication: true,
+      }),
+    });
+    (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (createSubmission as jest.Mock).mockResolvedValue(createSubmissionResponse);
+
+    GrantApplicantService.getInstance.mockReturnValue({
+      getGrantApplicant: jest.fn().mockResolvedValue(MOCK_GRANT_APPLICANT),
+    });
+
+    const mockUpdateMandatoryQuestion = jest.fn();
+    const mockCreateMandatoryQuestionForNewSubmission = jest
+      .fn()
+      .mockResolvedValue({ ...grantMandatoryQuestion });
+    GrantMandatoryQuestionService.getInstance.mockReturnValue({
+      getMandatoryQuestionById: jest.fn().mockResolvedValue({
+        ...grantMandatoryQuestion,
+        submissionId: 'previousSubmissionId',
+      }),
+      updateMandatoryQuestion: mockUpdateMandatoryQuestion,
+      createMandatoryQuestionForNewSubmission:
+        mockCreateMandatoryQuestionForNewSubmission,
+    });
+    GrantApplicantOrganisationProfileService.getInstance.mockReturnValue({
+      updateOrganisation: jest.fn().mockResolvedValue(MOCK_ORGANISATION_DATA),
+    });
+
+    await handler(
+      req({ body: { submissionName: 'My second application' } }),
+      res()
+    );
+
+    expect(mockCreateMandatoryQuestionForNewSubmission).toHaveBeenCalledWith(
+      'testJwt',
+      'submissionId'
+    );
+    expect(mockUpdateMandatoryQuestion).not.toHaveBeenCalled();
+    expect(mockedRedirect).toHaveBeenCalledWith(
+      303,
+      `http://localhost${routes.submissions.sections('submissionId')}`
+    );
+  });
+
   it('should redirect to error page when there is an error in the backend', async () => {
     await handler(req(), res());
 

--- a/packages/applicant/src/pages/api/create-submission.test.tsx
+++ b/packages/applicant/src/pages/api/create-submission.test.tsx
@@ -265,7 +265,7 @@ describe('API Handler Tests', () => {
     });
 
     const mockUpdateMandatoryQuestion = jest.fn();
-    const mockCreateMandatoryQuestionForNewSubmission = jest
+    const mockEnsureMandatoryQuestionForSubmission = jest
       .fn()
       .mockResolvedValue({ ...grantMandatoryQuestion });
     GrantMandatoryQuestionService.getInstance.mockReturnValue({
@@ -274,8 +274,8 @@ describe('API Handler Tests', () => {
         submissionId: 'previousSubmissionId',
       }),
       updateMandatoryQuestion: mockUpdateMandatoryQuestion,
-      createMandatoryQuestionForNewSubmission:
-        mockCreateMandatoryQuestionForNewSubmission,
+      ensureMandatoryQuestionForSubmission:
+        mockEnsureMandatoryQuestionForSubmission,
     });
     GrantApplicantOrganisationProfileService.getInstance.mockReturnValue({
       updateOrganisation: jest.fn().mockResolvedValue(MOCK_ORGANISATION_DATA),
@@ -286,7 +286,7 @@ describe('API Handler Tests', () => {
       res()
     );
 
-    expect(mockCreateMandatoryQuestionForNewSubmission).toHaveBeenCalledWith(
+    expect(mockEnsureMandatoryQuestionForSubmission).toHaveBeenCalledWith(
       'testJwt',
       'submissionId'
     );

--- a/packages/applicant/src/pages/mandatory-questions/start.page.test.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/start.page.test.tsx
@@ -166,6 +166,38 @@ describe('Mandatory Questions Start', () => {
       );
     });
 
+    it('should redirect to name submission when the resolved mandatory question is not completed but already belongs to a submission', async () => {
+      (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+      const existBySchemeIdAndApplicantId =
+        spiedExistBySchemeIdAndApplicantId.mockResolvedValue(true);
+      const getMandatoryQuestionBySchemeId =
+        spiedGetMandatoryQuestionBySchemeId.mockResolvedValue({
+          ...mandatoryQuestionData,
+          submissionId: '1',
+          status: 'IN_PROGRESS',
+          mandatoryQuestionsComplete: false,
+        });
+      const getGrantSchemeById = spiedGetGrantSchemeById.mockResolvedValue({
+        grantScheme: { id: 1, version: 2 },
+        grantApplication: { id: '1', allowsMultipleSubmissions: true },
+      });
+
+      const response = await getServerSideProps(getContext(getDefaultContext));
+
+      expect(response).toEqual({
+        redirect: {
+          destination: '/applications/1/name-submission',
+          permanent: false,
+        },
+      });
+      expect(existBySchemeIdAndApplicantId).toHaveBeenCalledWith('1', 'testJwt');
+      expect(getMandatoryQuestionBySchemeId).toHaveBeenCalledWith(
+        'testJwt',
+        '1'
+      );
+      expect(getGrantSchemeById).toHaveBeenCalledWith('1', 'testJwt');
+    });
+
     it('should redirect if there is an error retrieving MQ', async () => {
       (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
       spiedExistBySchemeIdAndApplicantId.mockRejectedValue(new Error());

--- a/packages/applicant/src/pages/mandatory-questions/start.page.tsx
+++ b/packages/applicant/src/pages/mandatory-questions/start.page.tsx
@@ -33,10 +33,15 @@ export async function getServerSideProps({
           schemeId
         );
 
-      // If mandatory questions are complete, skip to submission creation
+      // Skip the journey when the applicant has already established their organisation details for this scheme:
+      // either a mandatory question reached COMPLETED, or the resolved record already belongs to a submission. The
+      // backend resolves the most relevant record (completed, else submission-linked, else most recent), so this no
+      // longer depends on the status of the newest in-progress draft, which previously forced the full journey.
       if (
         mandatoryQuestion.mandatoryQuestionsComplete === true ||
-        mandatoryQuestion.status === 'COMPLETED'
+        mandatoryQuestion.status === 'COMPLETED' ||
+        (mandatoryQuestion.submissionId !== null &&
+          mandatoryQuestion.submissionId !== undefined)
       ) {
         // Get the scheme to determine version and get application ID
         const { grantScheme: scheme, grantApplication } =

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections.page.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections.page.test.tsx
@@ -15,6 +15,10 @@ import { createMockRouter } from '../../../testUtils/createMockRouter';
 import { getJwtFromCookies } from '../../../utils/jwt';
 import SubmissionSections, { getServerSideProps } from './sections.page';
 import { getApplicationStatusBySchemeId } from '../../../services/ApplicationService';
+import {
+  GrantMandatoryQuestionDto,
+  GrantMandatoryQuestionService,
+} from '../../../services/GrantMandatoryQuestionService';
 
 jest.mock('../../../services/SubmissionService');
 jest.mock('../../../utils/constants');
@@ -23,6 +27,11 @@ jest.mock('../../../utils/jwt');
 jest.mock('../../../services/ApplicationService', () => ({
   getApplicationStatusBySchemeId: jest.fn(),
 }));
+
+const spiedResolveMandatoryQuestionForSubmission = jest.spyOn(
+  GrantMandatoryQuestionService.prototype,
+  'resolveMandatoryQuestionForSubmission'
+);
 
 const context = {
   params: {
@@ -248,6 +257,51 @@ const questionDataStandardEligibilityResponseNull = {
 };
 
 describe('getServerSideProps', () => {
+  beforeEach(() => {
+    spiedResolveMandatoryQuestionForSubmission.mockReset();
+    spiedResolveMandatoryQuestionForSubmission.mockResolvedValue(
+      null as unknown as GrantMandatoryQuestionDto
+    );
+  });
+
+  it('resolves the mandatory question with the editable context when opening a draft', async () => {
+    (getSubmissionById as jest.Mock).mockReturnValue(propsWithAllValues);
+    (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (hasSubmissionBeenSubmitted as jest.Mock).mockReturnValue(false);
+    (isSubmissionReady as jest.Mock).mockReturnValue(true);
+    jest
+      .spyOn(GrantSchemeService.prototype, 'getGrantSchemeById')
+      .mockResolvedValue({ grantScheme: MOCK_GRANT_SCHEME });
+    (getQuestionById as jest.Mock).mockReturnValue(
+      questionDataStandardEligibilityResponseYes
+    );
+
+    await getServerSideProps(context);
+
+    expect(spiedResolveMandatoryQuestionForSubmission).toHaveBeenCalledWith(
+      'testJwt',
+      context.params.submissionId,
+      { hasBeenSubmitted: false }
+    );
+  });
+
+  it('passes the submitted context so the helper reads rather than heals', async () => {
+    (getSubmissionById as jest.Mock).mockReturnValue(propsWithAllValues);
+    (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
+    (hasSubmissionBeenSubmitted as jest.Mock).mockReturnValue(true);
+    jest
+      .spyOn(GrantSchemeService.prototype, 'getGrantSchemeById')
+      .mockResolvedValue({ grantScheme: MOCK_GRANT_SCHEME });
+
+    await getServerSideProps(context);
+
+    expect(spiedResolveMandatoryQuestionForSubmission).toHaveBeenCalledWith(
+      'testJwt',
+      context.params.submissionId,
+      { hasBeenSubmitted: true }
+    );
+  });
+
   it('should return sections, submissionId, applicationName', async () => {
     (getApplicationStatusBySchemeId as jest.Mock).mockResolvedValue(
       'PUBLISHED'

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections.page.tsx
@@ -3,6 +3,7 @@ import getConfig from 'next/config';
 import Link from 'next/link';
 import Layout from '../../../components/partials/Layout';
 import Meta from '../../../components/partials/Meta';
+import { GrantMandatoryQuestionService } from '../../../services/GrantMandatoryQuestionService';
 import { GrantSchemeService } from '../../../services/GrantSchemeService';
 import {
   getQuestionById,
@@ -33,6 +34,20 @@ export const getServerSideProps: GetServerSideProps<
   SubmissionSectionPage
 > = async ({ req, res, params }) => {
   const submissionId = params.submissionId.toString();
+  const jwt = getJwtFromCookies(req);
+
+  const hasBeenSubmitted = await hasSubmissionBeenSubmitted(submissionId, jwt);
+
+  // When an applicant opens an in-progress application, make sure it owns its own mandatory-questions record.
+  // If it was relying on a sibling submission's record, this creates its own, blanks the funding amount/location
+  // and reopens the funding section, forcing the funding details to be re-entered for THIS submission. Done before
+  // the reads below so the section statuses and submit-readiness reflect the healed state on this first load. The
+  // helper owns the heal-vs-read-vs-nothing policy; the result is unused here (the heal is a side-effect).
+  await GrantMandatoryQuestionService.getInstance().resolveMandatoryQuestionForSubmission(
+    jwt,
+    submissionId,
+    { hasBeenSubmitted }
+  );
 
   const {
     sections,
@@ -40,22 +55,12 @@ export const getServerSideProps: GetServerSideProps<
     applicationName,
     submissionName,
     grantSchemeId,
-  } = await getSubmissionById(submissionId, getJwtFromCookies(req));
+  } = await getSubmissionById(submissionId, jwt);
 
-  const submissionReady = await isSubmissionReady(
-    submissionId,
-    getJwtFromCookies(req)
-  );
-  const hasBeenSubmitted = await hasSubmissionBeenSubmitted(
-    submissionId,
-    getJwtFromCookies(req)
-  );
+  const submissionReady = await isSubmissionReady(submissionId, jwt);
   const grantSchemeService = GrantSchemeService.getInstance();
   const { grantScheme, grantApplication } =
-    await grantSchemeService.getGrantSchemeById(
-      grantSchemeId,
-      getJwtFromCookies(req)
-    );
+    await grantSchemeService.getGrantSchemeById(grantSchemeId, jwt);
 
   if (hasBeenSubmitted && !grantApplication?.allowsMultipleSubmissions) {
     return {
@@ -70,7 +75,7 @@ export const getServerSideProps: GetServerSideProps<
     submissionId,
     'ELIGIBILITY',
     'ELIGIBILITY',
-    getJwtFromCookies(req)
+    jwt
   );
 
   return {

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.test.tsx
@@ -129,9 +129,9 @@ const pageProps: SectionRecapPage = {
   backButtonUrl: '/submissions/12345678/sections',
 };
 
-const spiedGetMandatoryQuestionBySubmissionId = jest.spyOn(
+const spiedEnsureMandatoryQuestionForSubmission = jest.spyOn(
   GrantMandatoryQuestionService.prototype,
-  'getMandatoryQuestionBySubmissionId'
+  'ensureMandatoryQuestionForSubmission'
 );
 
 const mockMandatoryQuestionDto = (): GrantMandatoryQuestionDto => ({
@@ -165,7 +165,7 @@ describe('getServerSideProps', () => {
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
     (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
-      spiedGetMandatoryQuestionBySubmissionId,
+      spiedEnsureMandatoryQuestionForSubmission,
       mockMandatoryQuestionDto
     );
 
@@ -195,7 +195,7 @@ describe('getServerSideProps', () => {
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
     (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
-      spiedGetMandatoryQuestionBySubmissionId,
+      spiedEnsureMandatoryQuestionForSubmission,
       mockMandatoryQuestionDto
     );
 
@@ -247,7 +247,7 @@ describe('getServerSideProps', () => {
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
     (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
-      spiedGetMandatoryQuestionBySubmissionId,
+      spiedEnsureMandatoryQuestionForSubmission,
       mockMandatoryQuestionDto
     );
 
@@ -299,7 +299,7 @@ describe('getServerSideProps', () => {
     (getJwtFromCookies as jest.Mock).mockReturnValue('testJwt');
     (isApplicantEligible as jest.Mock).mockReturnValue(true);
     mockServiceMethod(
-      spiedGetMandatoryQuestionBySubmissionId,
+      spiedEnsureMandatoryQuestionForSubmission,
       mockMandatoryQuestionDto
     );
 

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.tsx
@@ -116,23 +116,17 @@ export const getServerSideProps: GetServerSideProps<SectionRecapPage> = async ({
     }
   }
 
-  const isOrganisationDetailsOrFunding =
-    sectionId === 'ORGANISATION_DETAILS' || sectionId === 'FUNDING_DETAILS';
-  let mandatoryQuestionId = null;
-  let isIndividual = false;
-  if (isOrganisationDetailsOrFunding) {
-    const mandatoryQuestionService =
-      GrantMandatoryQuestionService.getInstance();
-    // Editing organisation/funding details: make sure this submission owns its mandatory question
-    // before building the "Change" links, so edits land on this submission rather than a shared sibling.
-    const mandatoryQuestionDto =
-      await mandatoryQuestionService.ensureMandatoryQuestionForSubmission(
-        jwt,
-        submissionId
-      );
-    mandatoryQuestionId = mandatoryQuestionDto.id;
-    isIndividual = mandatoryQuestionDto.orgType === 'I am applying as an individual';
-  }
+  // The helper heals + returns this submission's mandatory question for the organisation/funding sections,
+  // and returns null for any other section, so the "Change" links are only built where one applies.
+  const mandatoryQuestionDto =
+    await GrantMandatoryQuestionService.getInstance().resolveMandatoryQuestionForSubmission(
+      jwt,
+      submissionId,
+      { sectionId }
+    );
+  const mandatoryQuestionId = mandatoryQuestionDto?.id ?? null;
+  const isIndividual =
+    mandatoryQuestionDto?.orgType === 'I am applying as an individual';
 
   const section = await getSectionById(submissionId, sectionId, jwt);
 

--- a/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/sections/[sectionId]/index.page.tsx
@@ -123,10 +123,12 @@ export const getServerSideProps: GetServerSideProps<SectionRecapPage> = async ({
   if (isOrganisationDetailsOrFunding) {
     const mandatoryQuestionService =
       GrantMandatoryQuestionService.getInstance();
+    // Editing organisation/funding details: make sure this submission owns its mandatory question
+    // before building the "Change" links, so edits land on this submission rather than a shared sibling.
     const mandatoryQuestionDto =
-      await mandatoryQuestionService.getMandatoryQuestionBySubmissionId(
-        submissionId,
-        jwt
+      await mandatoryQuestionService.ensureMandatoryQuestionForSubmission(
+        jwt,
+        submissionId
       );
     mandatoryQuestionId = mandatoryQuestionDto.id;
     isIndividual = mandatoryQuestionDto.orgType === 'I am applying as an individual';

--- a/packages/applicant/src/pages/submissions/[submissionId]/summary.page.test.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/summary.page.test.tsx
@@ -61,6 +61,11 @@ const spiedGetMandatoryQuestionBySubmissionId = jest.spyOn(
   'getMandatoryQuestionBySubmissionId'
 );
 
+const spiedEnsureMandatoryQuestionForSubmission = jest.spyOn(
+  GrantMandatoryQuestionService.prototype,
+  'ensureMandatoryQuestionForSubmission'
+);
+
 const context = {
   params: {
     submissionId: '12345678',
@@ -188,6 +193,11 @@ mockServiceMethod(
   mockMandatoryQuestionDto
 );
 
+mockServiceMethod(
+  spiedEnsureMandatoryQuestionForSubmission,
+  mockMandatoryQuestionDto
+);
+
 (getQuestionById as jest.Mock).mockImplementation(
   async (_submissionId, _sectionId, questionId, _jwt) => {
     return {
@@ -226,6 +236,12 @@ describe('getServerSideProps', () => {
       context.params.submissionId,
       'testJwt'
     );
+    // Draft submission: ensure it owns its mandatory question (so "Change" edits this submission)
+    expect(spiedEnsureMandatoryQuestionForSubmission).toHaveBeenCalledWith(
+      'testJwt',
+      '12345678'
+    );
+    expect(spiedGetMandatoryQuestionBySubmissionId).not.toHaveBeenCalled();
   });
 
   it('should return correct object from server side props with no token', async () => {
@@ -274,6 +290,12 @@ describe('getServerSideProps', () => {
       context.params.submissionId,
       'testJwt'
     );
+    // Submitted submission is read-only: do not create/mutate the mandatory question
+    expect(spiedGetMandatoryQuestionBySubmissionId).toHaveBeenCalledWith(
+      '12345678',
+      'testJwt'
+    );
+    expect(spiedEnsureMandatoryQuestionForSubmission).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
@@ -69,26 +69,15 @@ export const getServerSideProps: GetServerSideProps<
     })
   );
 
-  const isEditable = !hasBeenSubmitted && grantApplicationStatus !== 'REMOVED';
-  let mandatoryQuestionId = null;
-  try {
-    const mandatoryQuestionService =
-      GrantMandatoryQuestionService.getInstance();
-    // For an editable (draft) submission, make sure it owns its mandatory question so the summary
-    // "Change" links edit this submission rather than a shared sibling. Read-only views stay pure reads.
-    const mandatoryQuestionDto = isEditable
-      ? await mandatoryQuestionService.ensureMandatoryQuestionForSubmission(
-          jwt,
-          submissionId
-        )
-      : await mandatoryQuestionService.getMandatoryQuestionBySubmissionId(
-          submissionId,
-          jwt
-        );
-    mandatoryQuestionId = mandatoryQuestionDto?.id || null;
-  } catch (e) {
-    // do nothing
-  }
+  // The helper owns the heal-vs-read policy: an editable (draft) summary heals so the "Change" links edit
+  // this submission rather than a shared sibling, while a submitted/removed one stays a plain read.
+  const mandatoryQuestionDto =
+    await GrantMandatoryQuestionService.getInstance().resolveMandatoryQuestionForSubmission(
+      jwt,
+      submissionId,
+      { hasBeenSubmitted, grantApplicationStatus }
+    );
+  const mandatoryQuestionId = mandatoryQuestionDto?.id ?? null;
 
   return {
     props: {

--- a/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
+++ b/packages/applicant/src/pages/submissions/[submissionId]/summary.page.tsx
@@ -69,15 +69,22 @@ export const getServerSideProps: GetServerSideProps<
     })
   );
 
+  const isEditable = !hasBeenSubmitted && grantApplicationStatus !== 'REMOVED';
   let mandatoryQuestionId = null;
   try {
     const mandatoryQuestionService =
       GrantMandatoryQuestionService.getInstance();
-    const mandatoryQuestionDto =
-      await mandatoryQuestionService.getMandatoryQuestionBySubmissionId(
-        submissionId,
-        jwt
-      );
+    // For an editable (draft) submission, make sure it owns its mandatory question so the summary
+    // "Change" links edit this submission rather than a shared sibling. Read-only views stay pure reads.
+    const mandatoryQuestionDto = isEditable
+      ? await mandatoryQuestionService.ensureMandatoryQuestionForSubmission(
+          jwt,
+          submissionId
+        )
+      : await mandatoryQuestionService.getMandatoryQuestionBySubmissionId(
+          submissionId,
+          jwt
+        );
     mandatoryQuestionId = mandatoryQuestionDto?.id || null;
   } catch (e) {
     // do nothing

--- a/packages/applicant/src/services/GrantMandatoryQuestionService.test.tsx
+++ b/packages/applicant/src/services/GrantMandatoryQuestionService.test.tsx
@@ -235,6 +235,105 @@ describe('ensureMandatoryQuestionForSubmission', () => {
   });
 });
 
+describe('resolveMandatoryQuestionForSubmission', () => {
+  const postSpy = jest.spyOn(axios, 'post');
+  const getSpy = jest.spyOn(axios, 'get');
+
+  const SUBMISSION_ID = 'sub-123';
+  const { serverRuntimeConfig } = getConfig();
+  const BACKEND_HOST = serverRuntimeConfig.backendHost;
+  const ensureUrl = `${BACKEND_HOST}/grant-mandatory-questions/ensure-mandatory-question/${SUBMISSION_ID}`;
+  const readUrl = `${BACKEND_HOST}/grant-mandatory-questions/get-by-submission/${SUBMISSION_ID}`;
+
+  beforeEach(() => {
+    postSpy.mockClear();
+    getSpy.mockClear();
+  });
+
+  it('heals (POST ensure) for an editable submission', async () => {
+    const dto: GrantMandatoryQuestionDto = { id: 'mq-1' };
+    mock.onPost(ensureUrl).reply(200, dto);
+
+    const result = await subject.resolveMandatoryQuestionForSubmission(
+      'testJwt',
+      SUBMISSION_ID,
+      { hasBeenSubmitted: false }
+    );
+
+    expect(result).toEqual(dto);
+    expect(postSpy).toHaveBeenCalledWith(ensureUrl, {}, expect.anything());
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('reads (GET) when the submission has been submitted', async () => {
+    const dto: GrantMandatoryQuestionDto = { id: 'mq-2' };
+    mock.onGet(readUrl).reply(200, dto);
+
+    const result = await subject.resolveMandatoryQuestionForSubmission(
+      'testJwt',
+      SUBMISSION_ID,
+      { hasBeenSubmitted: true }
+    );
+
+    expect(result).toEqual(dto);
+    expect(getSpy).toHaveBeenCalledWith(readUrl, expect.anything());
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('reads (GET) when the grant application has been REMOVED', async () => {
+    const dto: GrantMandatoryQuestionDto = { id: 'mq-3' };
+    mock.onGet(readUrl).reply(200, dto);
+
+    const result = await subject.resolveMandatoryQuestionForSubmission(
+      'testJwt',
+      SUBMISSION_ID,
+      { hasBeenSubmitted: false, grantApplicationStatus: 'REMOVED' }
+    );
+
+    expect(result).toEqual(dto);
+    expect(getSpy).toHaveBeenCalledWith(readUrl, expect.anything());
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('heals for an editable organisation/funding section', async () => {
+    const dto: GrantMandatoryQuestionDto = { id: 'mq-4' };
+    mock.onPost(ensureUrl).reply(200, dto);
+
+    const result = await subject.resolveMandatoryQuestionForSubmission(
+      'testJwt',
+      SUBMISSION_ID,
+      { sectionId: 'FUNDING_DETAILS' }
+    );
+
+    expect(result).toEqual(dto);
+    expect(postSpy).toHaveBeenCalledWith(ensureUrl, {}, expect.anything());
+  });
+
+  it('returns null without any call for a non mandatory-question section', async () => {
+    const result = await subject.resolveMandatoryQuestionForSubmission(
+      'testJwt',
+      SUBMISSION_ID,
+      { sectionId: 'ELIGIBILITY' }
+    );
+
+    expect(result).toBeNull();
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the backend call fails', async () => {
+    mock.onPost(ensureUrl).reply(500);
+
+    const result = await subject.resolveMandatoryQuestionForSubmission(
+      'testJwt',
+      SUBMISSION_ID,
+      { hasBeenSubmitted: false }
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
 describe('Axios call to existBySchemeIdAndApplicantId', () => {
   const spy = jest.spyOn(axios, 'get');
 

--- a/packages/applicant/src/services/GrantMandatoryQuestionService.test.tsx
+++ b/packages/applicant/src/services/GrantMandatoryQuestionService.test.tsx
@@ -202,6 +202,39 @@ describe('create mandatoryQuestion', () => {
   });
 });
 
+describe('ensureMandatoryQuestionForSubmission', () => {
+  const spy = jest.spyOn(axios, 'post');
+
+  const SUBMISSION_ID = 'sub-123';
+  it('should send a request to ensure the per-submission mandatory question', async () => {
+    const MockMandatoryQuestionData: GrantMandatoryQuestionDto = {
+      id: 'mq-123',
+      submissionId: SUBMISSION_ID,
+    };
+    const { serverRuntimeConfig } = getConfig();
+    const BACKEND_HOST = serverRuntimeConfig.backendHost;
+    const expectedUrl = `${BACKEND_HOST}/grant-mandatory-questions/ensure-mandatory-question/${SUBMISSION_ID}`;
+    mock.onPost(expectedUrl).reply(200, MockMandatoryQuestionData);
+
+    const result = await subject.ensureMandatoryQuestionForSubmission(
+      'testJwt',
+      SUBMISSION_ID
+    );
+
+    expect(result).toEqual(MockMandatoryQuestionData);
+    expect(spy).toHaveBeenCalledWith(
+      expectedUrl,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer testJwt`,
+          Accept: 'application/json',
+        },
+      }
+    );
+  });
+});
+
 describe('Axios call to existBySchemeIdAndApplicantId', () => {
   const spy = jest.spyOn(axios, 'get');
 

--- a/packages/applicant/src/services/GrantMandatoryQuestionService.test.tsx
+++ b/packages/applicant/src/services/GrantMandatoryQuestionService.test.tsx
@@ -74,7 +74,7 @@ describe('Axios call to get mandatory question data by submission id', () => {
   const spy = jest.spyOn(axios, 'get');
 
   it('should get mandatoryQuestion data by submission id', async () => {
-    const SUBMISSION_ID = '1';
+    const SUBMISSION_ID = '3a6cfe2d-bf58-440d-9e07-3579c7dcf206';
     const MockMandatoryQuestionData: GrantMandatoryQuestionDto = {
       schemeId: 1,
       submissionId: null,
@@ -205,7 +205,7 @@ describe('create mandatoryQuestion', () => {
 describe('ensureMandatoryQuestionForSubmission', () => {
   const spy = jest.spyOn(axios, 'post');
 
-  const SUBMISSION_ID = 'sub-123';
+  const SUBMISSION_ID = '7c9e6679-7425-40de-944b-e07fc1f90ae7';
   it('should send a request to ensure the per-submission mandatory question', async () => {
     const MockMandatoryQuestionData: GrantMandatoryQuestionDto = {
       id: 'mq-123',
@@ -233,13 +233,22 @@ describe('ensureMandatoryQuestionForSubmission', () => {
       }
     );
   });
+
+  it('rejects a submissionId that is not a valid UUID without making a request', async () => {
+    spy.mockClear();
+
+    await expect(
+      subject.ensureMandatoryQuestionForSubmission('testJwt', '../evil-host')
+    ).rejects.toThrow('Invalid submissionId format');
+    expect(spy).not.toHaveBeenCalled();
+  });
 });
 
 describe('resolveMandatoryQuestionForSubmission', () => {
   const postSpy = jest.spyOn(axios, 'post');
   const getSpy = jest.spyOn(axios, 'get');
 
-  const SUBMISSION_ID = 'sub-123';
+  const SUBMISSION_ID = '3a6cfe2d-bf58-440d-9e07-3579c7dcf209';
   const { serverRuntimeConfig } = getConfig();
   const BACKEND_HOST = serverRuntimeConfig.backendHost;
   const ensureUrl = `${BACKEND_HOST}/grant-mandatory-questions/ensure-mandatory-question/${SUBMISSION_ID}`;
@@ -331,6 +340,18 @@ describe('resolveMandatoryQuestionForSubmission', () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  it('returns null (no request) when the submissionId is not a valid UUID', async () => {
+    const result = await subject.resolveMandatoryQuestionForSubmission(
+      'testJwt',
+      '../evil-host',
+      { hasBeenSubmitted: false }
+    );
+
+    expect(result).toBeNull();
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/applicant/src/services/GrantMandatoryQuestionService.ts
+++ b/packages/applicant/src/services/GrantMandatoryQuestionService.ts
@@ -20,6 +20,16 @@ export class GrantMandatoryQuestionService {
     return GrantMandatoryQuestionService.instance;
   }
 
+  private validateSubmissionId(submissionId: string): string {
+    const trimmedSubmissionId = submissionId?.trim();
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!trimmedSubmissionId || !uuidRegex.test(trimmedSubmissionId)) {
+      throw new Error('Invalid submissionId format');
+    }
+    return trimmedSubmissionId;
+  }
+
   public async getMandatoryQuestionById(
     mandatoryQuestionId: string,
     jwt: string
@@ -35,8 +45,11 @@ export class GrantMandatoryQuestionService {
     submissionId: string,
     jwt: string
   ): Promise<GrantMandatoryQuestionDto> {
+    const safeSubmissionId = encodeURIComponent(
+      this.validateSubmissionId(submissionId)
+    );
     const { data } = await axios.get<GrantMandatoryQuestionDto>(
-      `${this.BACKEND_HOST}/grant-mandatory-questions/get-by-submission/${submissionId}`,
+      `${this.BACKEND_HOST}/grant-mandatory-questions/get-by-submission/${safeSubmissionId}`,
       axiosConfig(jwt)
     );
     return data;
@@ -87,8 +100,11 @@ export class GrantMandatoryQuestionService {
     jwt: string,
     submissionId: string
   ): Promise<GrantMandatoryQuestionDto> {
+    const safeSubmissionId = encodeURIComponent(
+      this.validateSubmissionId(submissionId)
+    );
     const { data } = await axios.post<GrantMandatoryQuestionDto>(
-      `${this.BACKEND_HOST}/grant-mandatory-questions/ensure-mandatory-question/${submissionId}`,
+      `${this.BACKEND_HOST}/grant-mandatory-questions/ensure-mandatory-question/${safeSubmissionId}`,
       {},
       axiosConfig(jwt)
     );

--- a/packages/applicant/src/services/GrantMandatoryQuestionService.ts
+++ b/packages/applicant/src/services/GrantMandatoryQuestionService.ts
@@ -83,6 +83,19 @@ export class GrantMandatoryQuestionService {
     return data;
   }
 
+  public async createMandatoryQuestionForNewSubmission(
+    jwt: string,
+    submissionId: string
+  ): Promise<GrantMandatoryQuestionDto> {
+    const { data } = await axios.post<GrantMandatoryQuestionDto>(
+      `${this.BACKEND_HOST}/grant-mandatory-questions/new-submission/${submissionId}`,
+      {},
+      axiosConfig(jwt)
+    );
+
+    return data;
+  }
+
   public async existBySchemeIdAndApplicantId(schemeId: string, jwt: string) {
     const { data } = await axios.get<boolean>(
       `${this.BACKEND_HOST}/grant-mandatory-questions/scheme/${schemeId}/exists`,

--- a/packages/applicant/src/services/GrantMandatoryQuestionService.ts
+++ b/packages/applicant/src/services/GrantMandatoryQuestionService.ts
@@ -96,6 +96,19 @@ export class GrantMandatoryQuestionService {
     return data;
   }
 
+  public async ensureMandatoryQuestionForSubmission(
+    jwt: string,
+    submissionId: string
+  ): Promise<GrantMandatoryQuestionDto> {
+    const { data } = await axios.post<GrantMandatoryQuestionDto>(
+      `${this.BACKEND_HOST}/grant-mandatory-questions/ensure-mandatory-question/${submissionId}`,
+      {},
+      axiosConfig(jwt)
+    );
+
+    return data;
+  }
+
   public async existBySchemeIdAndApplicantId(schemeId: string, jwt: string) {
     const { data } = await axios.get<boolean>(
       `${this.BACKEND_HOST}/grant-mandatory-questions/scheme/${schemeId}/exists`,

--- a/packages/applicant/src/services/GrantMandatoryQuestionService.ts
+++ b/packages/applicant/src/services/GrantMandatoryQuestionService.ts
@@ -83,19 +83,6 @@ export class GrantMandatoryQuestionService {
     return data;
   }
 
-  public async createMandatoryQuestionForNewSubmission(
-    jwt: string,
-    submissionId: string
-  ): Promise<GrantMandatoryQuestionDto> {
-    const { data } = await axios.post<GrantMandatoryQuestionDto>(
-      `${this.BACKEND_HOST}/grant-mandatory-questions/new-submission/${submissionId}`,
-      {},
-      axiosConfig(jwt)
-    );
-
-    return data;
-  }
-
   public async ensureMandatoryQuestionForSubmission(
     jwt: string,
     submissionId: string
@@ -109,6 +96,40 @@ export class GrantMandatoryQuestionService {
     return data;
   }
 
+  /**
+   * Single entry point a page uses to obtain the mandatory question a submission should edit/display.
+   * The caller passes only its raw context; this method owns the whole policy:
+   *  - non mandatory-question section (e.g. eligibility/custom): nothing to do, returns null;
+   *  - editable submission: heals (ensures the submission owns its own mandatory question, blanking
+   *    funding for a borrowed record) and returns it;
+   *  - non-editable submission (submitted/removed): a plain read.
+   * Any backend error resolves to null so a page render is never broken by this.
+   */
+  public async resolveMandatoryQuestionForSubmission(
+    jwt: string,
+    submissionId: string,
+    context: MandatoryQuestionContext = {}
+  ): Promise<GrantMandatoryQuestionDto | null> {
+    const isEditable =
+      !context.hasBeenSubmitted && context.grantApplicationStatus !== 'REMOVED';
+    const isMandatoryQuestionContext =
+      !context.sectionId ||
+      context.sectionId === 'ORGANISATION_DETAILS' ||
+      context.sectionId === 'FUNDING_DETAILS';
+
+    if (!isMandatoryQuestionContext) {
+      return null;
+    }
+
+    try {
+      return isEditable
+        ? await this.ensureMandatoryQuestionForSubmission(jwt, submissionId)
+        : await this.getMandatoryQuestionBySubmissionId(submissionId, jwt);
+    } catch (e) {
+      return null;
+    }
+  }
+
   public async existBySchemeIdAndApplicantId(schemeId: string, jwt: string) {
     const { data } = await axios.get<boolean>(
       `${this.BACKEND_HOST}/grant-mandatory-questions/scheme/${schemeId}/exists`,
@@ -117,6 +138,12 @@ export class GrantMandatoryQuestionService {
     return data;
   }
 }
+export interface MandatoryQuestionContext {
+  hasBeenSubmitted?: boolean;
+  grantApplicationStatus?: string;
+  sectionId?: string;
+}
+
 export interface GrantMandatoryQuestionDto {
   id?: string;
   name?: string;


### PR DESCRIPTION
## Description

Ticket: GAP-2795 — <paste Jira link>

Frontend support for submitting multiple applications to the same scheme, where each submission has its own mandatory-questions (MQ) record. Consolidates the per-submission "ensure it owns its MQ" logic into a single self-contained helper, and repoints submission creation at the unified backend endpoint.

Changes:
- New single entry point `GrantMandatoryQuestionService.resolveMandatoryQuestionForSubmission(jwt, submissionId, context)` that owns the whole policy: editable submission -> ensure it owns its MQ (blanking funding), submitted/removed -> plain read, non-MQ section -> no-op, and any backend error resolves to null so a page render is never broken.
- Rewired the three submission pages to be "dumb" callers passing only their raw context: the application overview (`sections.page.tsx`), the section recap (`sections/[sectionId]/index.page.tsx`) and the summary/check-your-answers (`summary.page.tsx`).
- Removed the frontend `createMandatoryQuestionForNewSubmission` method and repointed `pages/api/create-submission.page.tsx` to `ensureMandatoryQuestionForSubmission` (the backend consolidated these into one endpoint).

Dependencies:
- Requires the backend PR in `gap-find-applicant-backend` (the `ensure-mandatory-question` endpoint; the `/new-submission` endpoint has been removed).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

- [x] Unit Test — Jest applicant suite green; added unit tests for `resolveMandatoryQuestionForSubmission` and updated the overview/recap/summary page tests and the `create-submission` test.
- [ ] Integration Test (if applicable) — N/A
- [ ] End to End Test (if applicable) — manual local testing of the multi-application create/edit/submit journey

## Screenshots (if appropriate):

<attach before/after of the FUNDING_DETAILS section status / "answer every question before completing" message if you want a UI screenshot>

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.